### PR TITLE
Implementing redis and ldap support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY --chown=nobody rootfs/ /
 
 # crond needs root, so install dcron and cap package and set the capabilities
 # on dcron binary https://github.com/inter169/systs/blob/master/alpine/crond/README.md
-RUN apk add --no-cache dcron libcap php8-sodium php8-exif && \
+RUN apk add --no-cache dcron libcap php8-sodium php8-exif php8-pecl-redis php8-ldap && \
     chown nobody:nobody /usr/sbin/crond && \
     setcap cap_setgid=ep /usr/sbin/crond
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ ENV MOODLE_URL=https://github.com/moodle/moodle/archive/MOODLE_401_STABLE.tar.gz
     DB_PASS=moodle \
     DB_PREFIX=mdl_ \
     SSLPROXY=false \
+    MY_CERTIFICATES=none \
     MOODLE_EMAIL=user@example.com \
     MOODLE_LANGUAGE=en \
     MOODLE_SITENAME=New-Site \

--- a/rootfs/docker-entrypoint-init.d/02-configure-moodle.sh
+++ b/rootfs/docker-entrypoint-init.d/02-configure-moodle.sh
@@ -5,16 +5,21 @@
 set -eo pipefail
 
 # Check that the database is available
-echo "Waiting for $database:$port to be ready"
+echo "Waiting for database to be ready..."
 while ! nc -w 1 $DB_HOST $DB_PORT; do
     # Show some progress
     echo -n '.';
     sleep 1;
 done
-echo "$database is ready"
+echo -e "\n\nGreat, "$DB_HOST" is ready!"
 # Give it another 3 seconds.
 sleep 3;
 
+#Add trusted certificates to "ldap-truststore"
+if [ "$MY_CERTIFICATES" != 'none' ]; then
+    echo "Adding certificates to truststore..."
+    echo "$MY_CERTIFICATES" | base64 -d > /etc/openldap/my-certificates/extra.pem
+fi
 
 # Check if the config.php file exists
 if [ ! -f /var/www/html/config.php ]; then

--- a/rootfs/etc/openldap/ldap.conf
+++ b/rootfs/etc/openldap/ldap.conf
@@ -1,0 +1,1 @@
+TLS_CACERT /etc/openldap/my-certificates/extra.pem


### PR DESCRIPTION
Hi Ernesto!
I was really happy when I found your repository for making docker image for Moodle.
But I was little disappointed when I knew that your images aren't supporting Redis and LDAP.

And I decided that I can improve your code for supporting this.  Also, I added opportunity to adding trusted certificates when you are using self-signed certificates on your AD by encoding your certificate or chain of certificates to base64 and provide this as a simple string variable when deploying.

This approach I've successfully tested in Kubernetes in my company.

Best regards,
Denis