### PR TITLE
Quick-and-dirty fix for issue #26 with gnu-libiconv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,10 @@ RUN apk add --no-cache dcron libcap php81-sodium php81-exif php81-pecl-redis php
     chown nobody:nobody /usr/sbin/crond && \
     setcap cap_setgid=ep /usr/sbin/crond
 
+# add a quick-and-dirty hack  to fix https://github.com/erseco/alpine-moodle/issues/26
+RUN apk add gnu-libiconv=1.15-r3 --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.13/community/ --allow-untrusted
+ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so
+
 USER nobody
 
 # Change MOODLE_XX_STABLE for new versions


### PR DESCRIPTION
This PR aims to fix issue #26, which was caused by an incompatible version of iconv in Alpine. Thanks to @jimsihk for the research and the proposed workaround.

Changes:

- Added gnu-libiconv-1.15-r3 from the Alpine 3.13 repository to replace the incompatible iconv version.
- Set LD_PRELOAD environment variable to use the preloadable_libiconv.so from gnu-libiconv.

```
RUN apk add gnu-libiconv=1.15-r3 --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.13/community/ --allow-untrusted
ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so
```

With these changes, we hope to have a functional Alpine-based solution. Please review and let me know if any further modifications are required.

Closes #26