### PR TITLE
 Update to PHP 8.3, Remove libiconv patch 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ARCH=
-FROM ${ARCH}erseco/alpine-php-webserver:latest
+FROM ${ARCH}erseco/alpine-php-webserver:php83
 
 LABEL maintainer="Ernesto Serrano <info@ernesto.es>"
 
@@ -8,13 +8,9 @@ COPY --chown=nobody rootfs/ /
 
 # crond needs root, so install dcron and cap package and set the capabilities
 # on dcron binary https://github.com/inter169/systs/blob/master/alpine/crond/README.md
-RUN apk add --no-cache dcron libcap php82-sodium php82-exif php82-pecl-redis php82-pecl-igbinary php82-ldap && \
+RUN apk add --no-cache dcron libcap php83-sodium php83-exif php83-pecl-redis php83-pecl-igbinary php83-ldap && \
     chown nobody:nobody /usr/sbin/crond && \
     setcap cap_setgid=ep /usr/sbin/crond
-
-# add a quick-and-dirty hack  to fix https://github.com/erseco/alpine-moodle/issues/26
-RUN apk add gnu-libiconv=1.15-r3 --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.13/community/ --allow-untrusted
-ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so
 
 USER nobody
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/erseco/alpine-moodle.svg)](https://hub.docker.com/r/erseco/alpine-moodle/)
 ![Docker Image Size](https://img.shields.io/docker/image-size/erseco/alpine-moodle)
 ![nginx 1.24.0](https://img.shields.io/badge/nginx-1.18-brightgreen.svg)
-![php 8.2](https://img.shields.io/badge/php-8.2-brightgreen.svg)
+![php 8.3](https://img.shields.io/badge/php-8.3-brightgreen.svg)
 ![moodle-4.3.1+](https://img.shields.io/badge/moodle-4.3-yellow)
 ![License MIT](https://img.shields.io/badge/license-MIT-blue.svg)
 
@@ -15,7 +15,7 @@ Repository: https://github.com/erseco/alpine-moodle
 
 * Built on the lightweight image https://github.com/erseco/alpine-php-webserver
 * Very small Docker image size (+/-70MB)
-* Uses PHP 8.21 for better performance, lower cpu usage & memory footprint
+* Uses PHP 8.3 for better performance, lower cpu usage & memory footprint
 * Support for HA installations: php-redis, php-ldap (also with self-signed certs)
 * Multi-arch support: 386, amd64, arm/v6, arm/v7, arm64, ppc64le, s390x
 * Optimized for 100 concurrent users

--- a/rootfs/docker-entrypoint-init.d/02-configure-moodle.sh
+++ b/rootfs/docker-entrypoint-init.d/02-configure-moodle.sh
@@ -55,7 +55,7 @@ check_db_availability() {
 # Function to generate config.php file
 generate_config_file() {
     echo "Generating config.php file..."
-    ENV_VAR='var' php82 -d max_input_vars=10000 /var/www/html/admin/cli/install.php \
+    ENV_VAR='var' php83 -d max_input_vars=10000 /var/www/html/admin/cli/install.php \
         --lang=$MOODLE_LANGUAGE \
         --wwwroot=$SITE_URL \
         --dataroot=/var/www/moodledata/ \
@@ -80,7 +80,7 @@ generate_config_file() {
 # Function to install the database
 install_database() {
     echo "Installing database..."
-    php82 -d max_input_vars=10000 /var/www/html/admin/cli/install_database.php \
+    php83 -d max_input_vars=10000 /var/www/html/admin/cli/install_database.php \
         --lang=$MOODLE_LANGUAGE \
         --adminuser=$MOODLE_USERNAME \
         --adminpass=$MOODLE_PASSWORD \
@@ -139,25 +139,25 @@ upgrade_config_file() {
 # Function to configure Moodle settings via CLI
 configure_moodle_settings() {
     echo "Configuring settings..."
-    php82 -d max_input_vars=10000 /var/www/html/admin/cli/cfg.php --name=pathtophp --set=/usr/bin/php82
-    php82 -d max_input_vars=10000 /var/www/html/admin/cli/cfg.php --name=pathtodu --set=/usr/bin/du
-    php82 -d max_input_vars=10000 /var/www/html/admin/cli/cfg.php --name=enableblogs --set=0
-    php82 -d max_input_vars=10000 /var/www/html/admin/cli/cfg.php --name=smtphosts --set="$SMTP_HOST:$SMTP_PORT"
-    php82 -d max_input_vars=10000 /var/www/html/admin/cli/cfg.php --name=smtpuser --set="$SMTP_USER"
-    php82 -d max_input_vars=10000 /var/www/html/admin/cli/cfg.php --name=smtppass --set="$SMTP_PASSWORD"
-    php82 -d max_input_vars=10000 /var/www/html/admin/cli/cfg.php --name=smtpsecure --set="$SMTP_PROTOCOL"
-    php82 -d max_input_vars=10000 /var/www/html/admin/cli/cfg.php --name=noreplyaddress --set="$MOODLE_MAIL_NOREPLY_ADDRESS"
-    php82 -d max_input_vars=10000 /var/www/html/admin/cli/cfg.php --name=emailsubjectprefix --set="$MOODLE_MAIL_PREFIX"
+    php83 -d max_input_vars=10000 /var/www/html/admin/cli/cfg.php --name=pathtophp --set=/usr/bin/php83
+    php83 -d max_input_vars=10000 /var/www/html/admin/cli/cfg.php --name=pathtodu --set=/usr/bin/du
+    php83 -d max_input_vars=10000 /var/www/html/admin/cli/cfg.php --name=enableblogs --set=0
+    php83 -d max_input_vars=10000 /var/www/html/admin/cli/cfg.php --name=smtphosts --set="$SMTP_HOST:$SMTP_PORT"
+    php83 -d max_input_vars=10000 /var/www/html/admin/cli/cfg.php --name=smtpuser --set="$SMTP_USER"
+    php83 -d max_input_vars=10000 /var/www/html/admin/cli/cfg.php --name=smtppass --set="$SMTP_PASSWORD"
+    php83 -d max_input_vars=10000 /var/www/html/admin/cli/cfg.php --name=smtpsecure --set="$SMTP_PROTOCOL"
+    php83 -d max_input_vars=10000 /var/www/html/admin/cli/cfg.php --name=noreplyaddress --set="$MOODLE_MAIL_NOREPLY_ADDRESS"
+    php83 -d max_input_vars=10000 /var/www/html/admin/cli/cfg.php --name=emailsubjectprefix --set="$MOODLE_MAIL_PREFIX"
 
     # Check if DEBUG is set to true
     if [ "${DEBUG:-false}" = "true" ]; then
         echo "Enabling debug mode..."
-        php82 /var/www/html/admin/cli/cfg.php --name=debug --set=32767 # DEVELOPER
-        php82 /var/www/html/admin/cli/cfg.php --name=debugdisplay --set=1
+        php83 /var/www/html/admin/cli/cfg.php --name=debug --set=32767 # DEVELOPER
+        php83 /var/www/html/admin/cli/cfg.php --name=debugdisplay --set=1
     else
         echo "Disabling debug mode..."
-        php82 /var/www/html/admin/cli/cfg.php --name=debug --set=0 # NONE
-        php82 /var/www/html/admin/cli/cfg.php --name=debugdisplay --set=0
+        php83 /var/www/html/admin/cli/cfg.php --name=debug --set=0 # NONE
+        php83 /var/www/html/admin/cli/cfg.php --name=debugdisplay --set=0
     fi
 
 }
@@ -174,9 +174,9 @@ final_configurations() {
 # Function to upgrade Moodle
 upgrade_moodle() {
     echo "Upgrading moodle..."
-    php82 -d max_input_vars=10000 /var/www/html/admin/cli/maintenance.php --enable
-    php82 -d max_input_vars=10000 /var/www/html/admin/cli/upgrade.php --non-interactive --allow-unstable
-    php82 -d max_input_vars=10000 /var/www/html/admin/cli/maintenance.php --disable
+    php83 -d max_input_vars=10000 /var/www/html/admin/cli/maintenance.php --enable
+    php83 -d max_input_vars=10000 /var/www/html/admin/cli/upgrade.php --non-interactive --allow-unstable
+    php83 -d max_input_vars=10000 /var/www/html/admin/cli/maintenance.php --disable
 }
 
 # Check the availability of the primary database
@@ -206,14 +206,14 @@ fi
 upgrade_config_file
 
 # Check if the database is already installed
-if php82 -d max_input_vars=10000 /var/www/html/admin/cli/isinstalled.php ; then
+if php83 -d max_input_vars=10000 /var/www/html/admin/cli/isinstalled.php ; then
     install_database
     configure_moodle_settings
     final_configurations
 else
     configure_moodle_settings
     echo "Upgrading admin user"
-    php82 -d max_input_vars=10000 /var/www/html/admin/cli/update_admin_user.php --username=$MOODLE_USERNAME --password=$MOODLE_PASSWORD --email=$MOODLE_EMAIL
+    php83 -d max_input_vars=10000 /var/www/html/admin/cli/update_admin_user.php --username=$MOODLE_USERNAME --password=$MOODLE_PASSWORD --email=$MOODLE_EMAIL
     if [ -z "$AUTO_UPDATE_MOODLE" ] || [ "$AUTO_UPDATE_MOODLE" = true ]; then
 
         upgrade_moodle
@@ -227,5 +227,5 @@ fi
 # Check if REDIS_HOST is set and not empty
 if [ -n "$REDIS_HOST" ]; then
     echo "Configuring redis cache..."
-    php82 -d max_input_vars=10000 /var/www/html/admin/cli/configure_redis.php ${REDIS_HOST}
+    php83 -d max_input_vars=10000 /var/www/html/admin/cli/configure_redis.php ${REDIS_HOST}
 fi

--- a/rootfs/etc/crontabs/nobody
+++ b/rootfs/etc/crontabs/nobody
@@ -1,2 +1,2 @@
 
-* * * * * /usr/bin/php82  /var/www/html/admin/cli/cron.php > /dev/null
+* * * * * /usr/bin/php83  /var/www/html/admin/cli/cron.php > /dev/null


### PR DESCRIPTION
I've submitted this pull request to address critical updates required for the upcoming Moodle release. However, it's important to note that we need to verify compatibility with Moodle, particularly with the anticipated Moodle 4.4 release which is expected to officially support PHP 8.3. Here are the key changes in this PR:

1. **Update Base Image**: The base image `alpine-php-webserver` has been updated to utilize the Alpine PHP 8.3 package. This update ensures compatibility with the latest PHP standards and improves overall stability and performance.

2. **Removal of Libiconv Patch**: With the update to PHP 8.3, the previously necessary `libiconv` patch is now redundant. Its removal is part of this update, streamlining the image and reducing unnecessary complexity.

3. **Preparation for Moodle Release**: These changes are in anticipation of the next Moodle release. They ensure that our environment remains in sync with the latest Moodle requirements, providing an optimized experience for all users.

For detailed discussions and the background of these changes, please refer to Issue #26 on our tracker.

I believe these updates are critical for maintaining the reliability and efficiency of our Moodle deployments. Your review and feedback on this PR would be greatly appreciated.

Best regards,

Ernesto