### PR TITLE
66 add automatic plugin type detection in cli plugin installation

### DIFF
--- a/.github/workflows/check-moodle-version.yml
+++ b/.github/workflows/check-moodle-version.yml
@@ -24,7 +24,8 @@ jobs:
     - name: Get Current Version from Git Tags
       id: get_current_version
       run: |
-        CURRENT_VERSION=$(git tag | sort -V | tail -n 1)
+        # Get the latest stable tag (no pre-release)
+        CURRENT_VERSION=$(git tag | grep -vE '(-rc|-beta|-alpha)' | sort -V | tail -n 1)
         echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
 
     - name: Compare Versions

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /Persistent
 .data
 .DS_Store
+.aider*

--- a/rootfs/var/www/html/admin/cli/install_plugin.php
+++ b/rootfs/var/www/html/admin/cli/install_plugin.php
@@ -10,7 +10,6 @@ $help = "Command line tool to install or update plugins.
 
 Options:
     -h --help                   Print this help.
-    --plugin=<pluginname>       The name of the plugin to install.
     --url=<pluginurl>           The URL to download the plugin from.
     --type=<plugintype>         The type of the plugin (e.g., mod, block, filter, theme, local). Defaults to mod.
     --run                       Execute install. If this option is not set, the script will run in dry mode.
@@ -67,8 +66,8 @@ if ($options['showsql']) {
     $DB->set_debug(true);
 }
 
-if (!$options['plugin'] && !$options['url']) {
-    cli_writeln('You must specify either a plugin name or a URL.');
+if (!$options['url']) {
+    cli_writeln('You must specify a URL to download the plugin.');
     cli_writeln($help);
     exit(0);
 }
@@ -119,27 +118,6 @@ if ($options['url']) {
         'component' => $pluginname,
         'zipfilepath' => $tempfile,
     ];
-} else {
-    $pluginDir = $CFG->dirroot . '/mod/' . $options['plugin'];
-
-    $plugininfo = get_plugin_info_from_version_file($pluginDir);
-    if (!$plugininfo) {
-        cli_error('Invalid plugin directory: ' . $pluginDir);
-    }
-
-    $pluginname = $plugininfo->component;
-    cli_writeln("Preparing to install plugin: $pluginname");
-
-    // Check if the plugin is already installed, unless forced
-    if ($pluginman->get_plugin_info($pluginname) && !$options['force']) {
-        cli_error("Plugin $pluginname is already installed. Use --force to reinstall.");
-    }
-
-    $plugins[] = (object)[
-        'component' => $pluginname,
-        'zipfilepath' => null,
-    ];
-}
 
 if ($options['run']) {
     cli_writeln('Installing plugin...');

--- a/rootfs/var/www/html/admin/cli/install_plugin.php
+++ b/rootfs/var/www/html/admin/cli/install_plugin.php
@@ -15,6 +15,7 @@ Options:
     --type=<plugintype>         The type of the plugin (e.g., mod, block, filter, theme, local). Defaults to mod.
     --run                       Execute install. If this option is not set, the script will run in dry mode.
     --force                     Force install even if plugin exists (useful for development).
+    --debug                     Enable debug mode to see detailed error messages.
     --showsql                   Show SQL queries before they are executed.
     --showdebugging             Show developer level debugging information.
 
@@ -37,6 +38,7 @@ list($options, $unrecognised) = cli_get_params([
     'run' => false,
     'force' => false,
     'showsql' => false,
+    'debug' => false,
     'showdebugging' => false,
 ], [
     'h' => 'help'
@@ -45,6 +47,11 @@ list($options, $unrecognised) = cli_get_params([
 if ($unrecognised) {
     $unrecognised = implode(PHP_EOL . '  ', $unrecognised);
     cli_error(get_string('cliunknowoption', 'core_admin', $unrecognised));
+}
+
+if ($options['debug']) {
+    set_debugging(DEBUG_DEVELOPER, true);
+    cli_writeln('Debug mode enabled.');
 }
 
 if ($options['help']) {

--- a/rootfs/var/www/html/admin/cli/install_plugin.php
+++ b/rootfs/var/www/html/admin/cli/install_plugin.php
@@ -257,18 +257,17 @@ function detect_and_move_plugin($pluginname, $sourcepath, $type) {
     if (array_key_exists($type, $plugin_types)) {
         $destination = $plugin_types[$type] . basename($sourcepath);
 
-            // Ensure the directory is writable before moving the plugin
-            if (!is_writable($path)) {
-                cli_error("Directory $path is not writable. Check permissions.");
-            }
+        // Ensure the directory is writable before moving the plugin
+        if (!is_writable($destination)) {
+            cli_error("Directory $destination is not writable. Check permissions.");
+        }
 
-            // Move the plugin to the correct directory
-            if (rename($sourcepath, $destination)) {
-                cli_writeln("Plugin moved to $destination.");
-                return $destination;
-            } else {
-                return false;
-            }
+        // Move the plugin to the correct directory
+        if (rename($sourcepath, $destination)) {
+            cli_writeln("Plugin moved to $destination.");
+            return $destination;
+        } else {
+            return false;
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced version checking for Moodle, focusing on stable releases only.
	- Added command-line options for plugin installation: `--type=<plugintype>` and `--debug` for improved flexibility and error handling.
  
- **Chores**
	- Updated `.gitignore` to exclude files starting with `.aider`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->