### PR TITLE
New approach for building docker images per each moodle tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,10 @@ jobs:
       # Step 4: Set up Docker Buildx
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        id: buildx
+        with:
+          driver-opts: |
+            network=host
+
 
       # Step 5: Login to DockerHub
       - name: Login to DockerHub
@@ -96,6 +99,9 @@ jobs:
           platforms: ${{ steps.prepare.outputs.platforms }}
           build-args: |
             MOODLE_VERSION=${{ steps.prepare.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
 
       # Step 9: Push to GitHub Container Registry
       - name: Push to GHCR
@@ -106,6 +112,10 @@ jobs:
           push: true
           tags: ${{ steps.prepare.outputs.ghcr-tags }}
           platforms: ${{ steps.prepare.outputs.platforms }}
+          build-args: |
+            MOODLE_VERSION=${{ steps.prepare.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       # Step 10: Update Docker Hub Description
       - name: Docker Hub Description

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,12 @@ on:
   push:
   pull_request:
   workflow_dispatch:
-    
+    inputs:
+      moodle_version:
+        description: 'Moodle version tag'
+        required: true
+        default: 'main'
+
 jobs:
   buildx:
     runs-on: ubuntu-latest
@@ -17,28 +22,32 @@ jobs:
       - name: Prepare
         id: prepare
         run: |
+          # Get version from input or default to 'main'
+          RAW_VERSION=${{ inputs.moodle_version || 'main' }}
+          
+          # Clean version (remove refs/tags/ prefix if present)
+          CLEAN_VERSION=$(echo "$RAW_VERSION" | sed 's/^refs\/tags\///; s/\//-/g')
+          
           GHCR_IMAGE=ghcr.io/${GITHUB_REPOSITORY}
           DOCKER_PLATFORMS=linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/386,linux/ppc64le,linux/s390x
 
-          VERSION=$(echo ${GITHUB_REF#refs/*/} | sed 's/\//-/g') # Replace / with - in tag name
-          TAGS="${GITHUB_REPOSITORY}:${VERSION}"
+          # Base tags
+          TAGS="${GITHUB_REPOSITORY}:${CLEAN_VERSION}"
+          GHCR_TAGS="${GHCR_IMAGE}:${CLEAN_VERSION}"
 
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            TAGS="$TAGS,${GITHUB_REPOSITORY}:latest"
-          elif [[ $VERSION == "main" ]]; then
-            TAGS="$TAGS,${GITHUB_REPOSITORY}:beta"
-          fi
-
-          GHCR_TAGS="${GHCR_IMAGE}:${VERSION}"
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            GHCR_TAGS="$GHCR_TAGS,${GHCR_IMAGE}:latest"
-          elif [[ $VERSION == "main" ]]; then
-            GHCR_TAGS="$GHCR_TAGS,${GHCR_IMAGE}:beta"
+          # Add additional tags for specific cases
+          if [[ "$CLEAN_VERSION" == "main" ]]; then
+            TAGS+=",${GITHUB_REPOSITORY}:beta"
+            GHCR_TAGS+=",${GHCR_IMAGE}:beta"
+          elif [[ "$CLEAN_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            TAGS+=",${GITHUB_REPOSITORY}:latest"
+            GHCR_TAGS+=",${GHCR_IMAGE}:latest"
           fi
 
           echo "platforms=${DOCKER_PLATFORMS}" >> $GITHUB_OUTPUT
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
           echo "ghcr-tags=${GHCR_TAGS}" >> $GITHUB_OUTPUT
+          echo "version=${CLEAN_VERSION}" >> $GITHUB_OUTPUT
 
       # Step 3: Set up QEMU for multi-platform builds
       - name: Set up QEMU
@@ -85,6 +94,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.prepare.outputs.tags }}
           platforms: ${{ steps.prepare.outputs.platforms }}
+          build-args: |
+            MOODLE_VERSION=${{ steps.prepare.outputs.version }}
 
       # Step 9: Push to GitHub Container Registry
       - name: Push to GHCR

--- a/.github/workflows/check-moodle-version.yml
+++ b/.github/workflows/check-moodle-version.yml
@@ -1,59 +1,62 @@
-name: Check Moodle Version and Tag
+name: Sync Moodle Tags
 
 on:
   schedule:
-    - cron: '0 0 * * *' # Run this task daily
+    - cron: '0 0 * * *' # Daily at midnight
   workflow_dispatch: # Allows manually triggering
 
 jobs:
-  check-version-and-tag:
+  sync-tags:
     runs-on: ubuntu-latest
-
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    - name: Check Moodle Latest Version
-      id: check_moodle
-      run: |
-        LATEST_MOODLE_VERSION=$(curl -s https://api.github.com/repos/moodle/moodle/tags | jq -r '.[0].name')
-        echo "LATEST_MOODLE_VERSION=$LATEST_MOODLE_VERSION" >> $GITHUB_ENV
+      - name: Get Moodle tags
+        id: get-moodle-tags
+        run: |
+          MOODLE_TAGS=$(curl -s -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/moodle/moodle/tags" | jq -r '.[].name')
+          echo "moodle_tags<<EOF" >> $GITHUB_ENV
+          echo "$MOODLE_TAGS" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
 
-    - name: Get Current Version from Git Tags
-      id: get_current_version
-      run: |
-        # Get the latest stable tag (no pre-release)
-        CURRENT_VERSION=$(git tag | grep -vE '(-rc|-beta|-alpha)' | sort -V | tail -n 1)
-        echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
+      - name: Get existing tags
+        id: get-existing-tags
+        run: |
+          git fetch --tags
+          EXISTING_TAGS=$(git tag -l)
+          echo "existing_tags<<EOF" >> $GITHUB_ENV
+          echo "$EXISTING_TAGS" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
 
-    - name: Compare Versions
-      id: version_compare
-      uses: madhead/semver-utils@latest
-      with:
-        version: '${{ env.LATEST_MOODLE_VERSION }}'
-        compare-to: '${{ env.CURRENT_VERSION }}'
+      - name: Process missing tags
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: |
+          IFS=$'\n' read -rd '' -a moodle_tags <<< "${{ env.moodle_tags }}"
+          IFS=$'\n' read -rd '' -a existing_tags <<< "${{ env.existing_tags }}"
 
-    - name: Create Tag if New
-      if: steps.version_compare.outputs.comparison-result == '>'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        LATEST_MOODLE_VERSION: ${{ env.LATEST_MOODLE_VERSION }}
-        GH_PAT: ${{ secrets.GH_PAT }}
-      run: |
-        echo "Creating new tag for $LATEST_MOODLE_VERSION"
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git tag $LATEST_MOODLE_VERSION
-        git push origin $LATEST_MOODLE_VERSION
-        curl -X POST \
-          -H "Accept: application/vnd.github.v3+json" \
-          -H "Authorization: token $GH_PAT" \
-          https://api.github.com/repos/${{ github.repository }}/actions/workflows/build.yml/dispatches \
-          -d '{"ref":"refs/tags/'"$LATEST_MOODLE_VERSION"'"}'
+          for tag in "${moodle_tags[@]}"; do
+            if [[ "$tag" =~ ^v[0-9]+ ]]; then
+              if [[ ! " ${existing_tags[@]} " =~ " ${tag} " ]]; then
+                echo "Creating tag: $tag"
+                
+                # Create and push tag
+                git tag "$tag"
+                git push origin "$tag"
 
-    - name: No New Version
-      if: steps.version_compare.outputs.comparison-result != '>'
-      run: echo "Latest version is already tagged or is older."
-
+                # Trigger build workflow
+                curl -X POST \
+                  -H "Accept: application/vnd.github.v3+json" \
+                  -H "Authorization: token $GH_PAT" \
+                  https://api.github.com/repos/${{ github.repository }}/actions/workflows/build.yml/dispatches \
+                  -d '{
+                    "ref": "main",
+                    "inputs": {
+                      "moodle_version": "'"$tag"'"
+                    }
+                  }'
+              fi
+            fi
+          done

--- a/.github/workflows/check-moodle-version.yml
+++ b/.github/workflows/check-moodle-version.yml
@@ -38,7 +38,7 @@ jobs:
           IFS=$'\n' read -rd '' -a existing_tags <<< "${{ env.existing_tags }}"
 
           for tag in "${moodle_tags[@]}"; do
-            if [[ "$tag" =~ ^v[0-9]+ ]]; then
+            if [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               if [[ ! " ${existing_tags[@]} " =~ " ${tag} " ]]; then
                 echo "Creating tag: $tag"
                 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,19 @@ ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so
 
 USER nobody
 
-# Change MOODLE_XX_STABLE for new versions
-ENV MOODLE_URL=https://github.com/moodle/moodle/archive/MOODLE_405_STABLE.tar.gz \
+# By default, the main branch is used:
+ARG MOODLE_VERSION=main
+
+# Set default environment variables
+# 
+# To install a specific Moodle version, set MOODLE_VERSION to a branch or a release tag.
+# You can find the list of available tags at:
+# https://api.github.com/repos/moodle/moodle/tags
+#
+# Example:
+# MOODLE_VERSION=v4.5.3
+#
+ENV MOODLE_URL=https://github.com/moodle/moodle/tarball/refs/tags/${MOODLE_VERSION}
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \
     SITE_URL=http://localhost \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,20 +18,11 @@ ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so
 
 USER nobody
 
-# By default, the main branch is used:
+# Moodle version configuration
 ARG MOODLE_VERSION=main
 
 # Set default environment variables
-# 
-# To install a specific Moodle version, set MOODLE_VERSION to a branch or a release tag.
-# You can find the list of available tags at:
-# https://api.github.com/repos/moodle/moodle/tags
-#
-# Example:
-# MOODLE_VERSION=v4.5.3
-#
-ENV MOODLE_URL=https://github.com/moodle/moodle/tarball/refs/tags/${MOODLE_VERSION} \
-    LANG=en_US.UTF-8 \
+ENV LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \
     SITE_URL=http://localhost \
     DB_TYPE=pgsql \
@@ -65,5 +56,18 @@ ENV MOODLE_URL=https://github.com/moodle/moodle/tarball/refs/tags/${MOODLE_VERSI
     upload_max_filesize=50M \
     max_input_vars=5000
 
-RUN curl --location $MOODLE_URL | tar xz --strip-components=1 -C /var/www/html/
-
+# To use a specific Moodle version, set MOODLE_VERSION to git release tag.
+# You can find the list of available tags at:
+# https://api.github.com/repos/moodle/moodle/tags
+#
+# Example:
+# MOODLE_VERSION=v4.5.3
+#
+# Download and extract Moodle
+RUN if [ "$MOODLE_VERSION" = "main" ]; then \
+      MOODLE_URL="https://github.com/moodle/moodle/archive/main.tar.gz"; \
+    else \
+      MOODLE_URL="https://github.com/moodle/moodle/tarball/refs/tags/${MOODLE_VERSION}"; \
+    fi && \
+    echo "Downloading Moodle from: $MOODLE_URL" && \
+    curl -L "$MOODLE_URL" | tar xz --strip-components=1 -C /var/www/html/

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ARG MOODLE_VERSION=main
 # Example:
 # MOODLE_VERSION=v4.5.3
 #
-ENV MOODLE_URL=https://github.com/moodle/moodle/tarball/refs/tags/${MOODLE_VERSION}
+ENV MOODLE_URL=https://github.com/moodle/moodle/tarball/refs/tags/${MOODLE_VERSION} \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \
     SITE_URL=http://localhost \


### PR DESCRIPTION
This pull request introduces several enhancements to the GitHub Actions workflows and Dockerfile for better handling of Moodle versions. The main changes include adding support for specifying Moodle version tags, improving the tagging logic, and synchronizing Moodle tags.

Enhancements to GitHub Actions workflows:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R7-R11): Added `moodle_version` input to allow specifying the Moodle version tag during workflow dispatch. Improved the logic for setting Docker image tags based on the specified Moodle version. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R7-R11) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L20-R50) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R97-R98)

* [`.github/workflows/check-moodle-version.yml`](diffhunk://#diff-d0a3b16aaf58a5de66c4c271db4a6cf2c423768f32efeb6ea57147c75009d627L1-R62): Renamed the workflow to "Sync Moodle Tags" and updated the job to fetch Moodle tags and synchronize them with the repository. This includes creating missing tags and triggering the build workflow for new tags.

Enhancements to Dockerfile:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L21-R33): Introduced the `MOODLE_VERSION` argument to allow specifying a Moodle version (branch or release tag) and updated the `MOODLE_URL` environment variable to use this argument.