### PR TITLE
Better approach for cron

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,6 @@ LABEL maintainer="Ernesto Serrano <info@ernesto.es>"
 USER root
 COPY --chown=nobody rootfs/ /
 
-# crond needs root, so install dcron and cap package and set the capabilities
-# on dcron binary https://github.com/inter169/systs/blob/master/alpine/crond/README.md
-RUN apk add --no-cache dcron libcap php84-exif php84-pecl-redis php84-pecl-igbinary php84-ldap && \
-    chown nobody:nobody /usr/sbin/crond && \
-    setcap cap_setgid=ep /usr/sbin/crond
-
 # add a quick-and-dirty hack  to fix https://github.com/erseco/alpine-moodle/issues/26
 RUN apk add gnu-libiconv=1.15-r3 --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.13/community/ --allow-untrusted
 ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so
@@ -71,3 +65,5 @@ RUN if [ "$MOODLE_VERSION" = "main" ]; then \
     fi && \
     echo "Downloading Moodle from: $MOODLE_URL" && \
     curl -L "$MOODLE_URL" | tar xz --strip-components=1 -C /var/www/html/
+
+

--- a/rootfs/etc/service/cron/run
+++ b/rootfs/etc/service/cron/run
@@ -1,5 +1,10 @@
 #!/bin/sh
 
-# pipe stderr to stdout and run cron
+# pipe stderr to stdout and run moodle PHP cron tasks
+
+# This script will keep running for the defined keep-alive time (default 180 seconds)
+# and continuously check for tasks during that period
+# After that time, runit will restart the process automatically
 exec 2>&1
-exec /usr/sbin/crond -f
+cd /var/www/html
+exec /usr/bin/php84 /var/www/html/admin/cli/cron.php


### PR DESCRIPTION
This pull request includes several changes to the `Dockerfile` and a script in `rootfs/etc/service/cron/run` to improve the setup and execution of Moodle cron tasks. The most important changes include removing unnecessary packages and modifying the cron service script to run Moodle PHP cron tasks.

### Dockerfile changes:

* Removed the installation of `dcron`, `libcap`, and several PHP packages, and the associated setup for `crond`. This simplifies the Dockerfile and removes unnecessary dependencies.

### Script changes:

* Modified the `rootfs/etc/service/cron/run` script to run Moodle PHP cron tasks instead of the `crond` service. This change ensures that Moodle cron tasks are executed directly by PHP, improving the reliability of task execution.


Fix #77 