### PR TITLE
Explain better the new MOODLE_VERSION on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Docker Image Size](https://img.shields.io/docker/image-size/erseco/alpine-moodle)
 ![nginx 1.26](https://img.shields.io/badge/nginx-1.26-brightgreen.svg)
 ![php 8.4](https://img.shields.io/badge/php-8.4-brightgreen.svg)
-![moodle-4.5.0](https://img.shields.io/badge/moodle-4.5-yellow)
+![moodle](https://img.shields.io/badge/moodle-configurable-yellow)
 ![License MIT](https://img.shields.io/badge/license-MIT-blue.svg)
 <a href="https://www.buymeacoffee.com/erseco"><img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" height="20px"></a>
 
@@ -113,3 +113,19 @@ services:
       PRE_CONFIGURE_COMMANDS: "echo 'Running pre-configure commands'"
       POST_CONFIGURE_COMMANDS: "echo 'Running post-configure commands'"
 ```
+
+## Specifying a Moodle Version
+
+By default, this image uses the latest version of Moodle from the main branch. If you need to use a specific Moodle version, you can specify it using the `MOODLE_VERSION` build argument.
+
+To use a specific version, edit your docker-compose.yml file and uncomment the build section for the moodle service:
+
+```yaml
+moodle:
+  # image: erseco/alpine-moodle
+  build:
+    context: .
+    args:
+      MOODLE_VERSION: v4.5.3  # Replace with your desired version
+```
+You can find the list of available version tags at: https://github.com/moodle/moodle/tags

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,11 @@ services:
 
   moodle:
     image: erseco/alpine-moodle
-    build: .
+    # You can specify a specific Moodle version by uncommenting the build section below
+    # build:
+    #   context: .
+    #   args:
+    #     MOODLE_VERSION: v4.5.3  # Set to a specific Moodle version tag
     restart: unless-stopped
     environment:
       LANG: en_US.UTF-8


### PR DESCRIPTION
This pull request includes updates to the `README.md` and `docker-compose.yml` files to improve the flexibility and documentation of the Moodle Docker image. The most important changes are the addition of instructions for specifying a Moodle version and the update to the badge in the `README.md`.

Documentation improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R116-R131): Added a new section with instructions on how to specify a Moodle version using the `MOODLE_VERSION` build argument in the `docker-compose.yml` file.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R7): Updated the Moodle badge to be configurable instead of showing a fixed version.

Configuration updates:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L20-R24): Added comments and an example on how to specify a specific Moodle version by uncommenting the build section and setting the `MOODLE_VERSION` argument.