### PR TITLE
Add composer and behat to support scenario import (WIP)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,21 @@ LABEL maintainer="Ernesto Serrano <info@ernesto.es>"
 USER root
 COPY --chown=nobody rootfs/ /
 
+# Required packages for use behat
+RUN apk add --no-cache \
+        composer \
+        php83-dom \
+        php83-fileinfo \
+        php83-gd \
+        php83-intl \
+        php83-simplexml \
+        php83-sodium \
+        php83-tokenizer \
+        php83-xml \
+        php83-xmlreader \
+        php83-xmlwriter
+
+
 # add a quick-and-dirty hack  to fix https://github.com/erseco/alpine-moodle/issues/26
 RUN apk add gnu-libiconv=1.15-r3 --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.13/community/ --allow-untrusted
 ENV LD_PRELOAD=/usr/lib/preloadable_libiconv.so
@@ -66,4 +81,5 @@ RUN if [ "$MOODLE_VERSION" = "main" ]; then \
     echo "Downloading Moodle from: $MOODLE_URL" && \
     curl -L "$MOODLE_URL" | tar xz --strip-components=1 -C /var/www/html/
 
-
+# TODO
+RUN php admin/tool/behat/cli/init.php


### PR DESCRIPTION
This pull request includes updates to the `Dockerfile` to add required packages for Behat and initializes Behat for Moodle. The most important changes are as follows:

### Package Additions

* Added required PHP packages for Behat in the `Dockerfile` to ensure compatibility and functionality. These packages include `composer`, `php83-dom`, `php83-fileinfo`, `php83-gd`, `php83-intl`, `php83-simplexml`, `php83-sodium`, `php83-tokenizer`, `php83-xml`, `php83-xmlreader`, and `php83-xmlwriter`.

### Behat Initialization

* Added a command to initialize Behat for Moodle in the `Dockerfile` by running `php admin/tool/behat/cli/init.php`. This step is necessary to set up Behat for testing Moodle installations.…feature files to import scennarios (WIP)

You can import `.feature` like this to create a scenario

```
@core @test
Feature: Simple Moodle setup

  Scenario: Create a basic course with users and an assignment

    And the following "course" exists:
      | fullname    | Curso de prueba nuevo     |
      | shortname   | C1-test-20250403          |
      | category    | 0                         |
      | numsections | 3                         |
      | initsections| 1                         |

    And the following "users" exist:
      | username  | firstname | lastname | email                  |
      | teach04   | Alicia    | Gómez    | teach04@example.com    |
      | student04 | Juan      | Pérez    | student04@example.com  |

    And the following "course enrolments" exist:
      | user     | course           | role           |
      | teach04  | C1-test-20250403 | editingteacher |
      | student04| C1-test-20250403 | student        |

    And the following "activities" exist:
      | activity | name    | intro                | course           | idnumber | section | visible |
      | assign   | Tarea 1 | Primera tarea prueba | C1-test-20250403 | tarea1   | 1       | 1       |


```