### PR TITLE
Fixed redis cachestore config in old Moodle versions

### DIFF
--- a/rootfs/var/www/html/admin/cli/configure_redis.php
+++ b/rootfs/var/www/html/admin/cli/configure_redis.php
@@ -31,46 +31,69 @@ if (!$fp) {
 }
 fclose($fp);
 
-$cache = cache_config::instance();
-$stores = $cache->get_all_stores();
 
-// Check if the 'redis1' configuration already exists
-if (array_key_exists('redis1', $stores)) {
-    echo "Configuration 'redis1' already exists. Exiting.\n";
-    exit;
+/**
+ * Configure Redis cache store and mode mappings.
+ *
+ * @param string $name          Unique name for this instance.
+ * @param string $plugin        Cache store plugin name.
+ * @param array  $configuration Plugin-specific settings.
+ * @return void
+ */
+function configure_redis_store($name, $plugin, array $configuration) {
+    global $CFG;
+
+    // Include classes for modern Moodle versions
+    if (file_exists($CFG->dirroot . '/cache/classes/config_writer.php')) {
+        require_once($CFG->dirroot . '/cache/classes/config_writer.php');
+    }
+    // Fallback for older Moodle LTS versions
+    elseif (file_exists($CFG->dirroot . '/cache/locallib.php')) {
+        require_once($CFG->dirroot . '/cache/locallib.php');
+    } else {
+        mtrace("Cache library not found. Skipping Redis configuration.");
+        return;
+    }
+
+    // Get writer instance if available
+    if (!class_exists('cache_config_writer')) {
+        mtrace("Cache config writer class not available. Skipping Redis configuration.");
+        return;
+    }
+
+    $writer = cache_config_writer::instance();
+
+    // Add new store instance if it does not exist
+    $existing = cache_config::instance()->get_all_stores();
+    if (array_key_exists($name, $existing)) {
+        mtrace("Store instance '{$name}' already exists. Nothing to do.");
+        return;
+    }
+
+    try {
+        $writer->add_store_instance($name, $plugin, $configuration);
+        mtrace("Instance '{$name}' added successfully.");
+
+        // Define mode mappings
+        $modes = [
+            cache_store::MODE_APPLICATION => [$name],
+            cache_store::MODE_SESSION     => [$name],
+            cache_store::MODE_REQUEST     => ['default_request'],
+        ];
+        $writer->set_mode_mappings($modes);
+        mtrace("Mode mappings updated successfully.");
+    } catch (cache_exception $e) {
+        mtrace("Error adding cache instance: " . $e->getMessage());
+    }
 }
 
-// Include cache libraries
-require_once($CFG->dirroot.'/cache/classes/config_writer.php');
-
-// Get an instance of the cache_config_writer class
-$writer = cache_config_writer::instance();
-
-// Define the configuration for the new Redis cache store instance
-$name = 'redis1';  // Choose a unique name for this instance
-$plugin = 'redis';  // The name of the cache store plugin
-$configuration = array(
-    'server' => $redis_server,
-    'port' => 6379,
-    'serializer' => 2, // The faster igbinary serializer
+// Execute configuration
+configure_redis_store(
+    'redis1',
+    'redis',
+    [
+        'server'     => $redis_server,
+        'port'       => 6379,
+        'serializer' => 2, // igbinary serializer
+    ]
 );
-
-// Try to add the new Redis cache store instance
-try {
-    $writer->add_store_instance($name, $plugin, $configuration);
-    mtrace("Instance '{$name}' has been added successfully.");
-
-    // Prepare mode mappings
-    $mode_mappings = array(
-        cache_store::MODE_APPLICATION => array('redis1'),
-        cache_store::MODE_SESSION => array('redis1'),
-        cache_store::MODE_REQUEST => array('default_request'),
-    );
-
-    // Set mode mappings
-    $writer->set_mode_mappings($mode_mappings);
-    mtrace("Mode mappings have been updated successfully.");
-
-} catch (cache_exception $e) {
-    mtrace("Error adding cache instance: " . $e->getMessage());
-}


### PR DESCRIPTION
This pull request refactors the Redis configuration logic in the `configure_redis.php` script to improve modularity and maintainability. The changes include encapsulating the Redis configuration logic into a dedicated function and adding compatibility checks for different Moodle versions.

### Refactoring and modularization:

* Encapsulated the Redis cache store configuration logic into a new function, `configure_redis_store`, which accepts parameters for the store name, plugin, and configuration settings. This improves code readability and reusability.

### Compatibility improvements:

* Added version compatibility checks to include appropriate cache library files based on the Moodle version, ensuring the script works with both modern and older Moodle LTS versions.

### Error handling and logging:

* Improved error handling by adding checks for the existence of required classes and providing detailed log messages when prerequisites are missing or when configuration steps are skipped.