### PR TITLE
97 support moodle 5 1 structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ Repository: https://github.com/erseco/alpine-moodle
 - Built on the lightweight image https://github.com/erseco/alpine-php-webserver
 - Compact Docker image size (~100MB)
 - Uses PHP 8.3 FPM for better performance, lower cpu usage & memory footprint
-- Includes Composer and [Moosh CLI](https://github.com/tmuras/moosh)
+- Includes Composer.
+- Supports Moodle <5.1 and >=5.1 (detects /public directory automatically).
+- Includes Redis session handler support.
+- Includes [Moosh CLI](https://github.com/tmuras/moosh) for Moodle management.
+- Configurable via environment variables (see Dockerfile).
 - Support for HA installations: php-redis, php-ldap (also with self-signed certs)
 - Multi-arch support: 386, amd64, arm/v6, arm/v7, arm64, ppc64le, s390x
 - Optimized for 100 concurrent users
@@ -31,6 +35,25 @@ Repository: https://github.com/erseco/alpine-moodle
 - Logs are sent to container's STDOUT (`docker logs -f <container>`)
 - Extensible via pre/post configuration hooks  
 - Follows the KISS principle (Keep It Simple, Stupid) to make it easy to understand and adjust the image to your needs
+
+## Important notes
+
+- **Change default credentials**: Always override `MOODLE_USERNAME` and `MOODLE_PASSWORD` with secure values.
+- **Moodle ≥ 5.1**: The script automatically reconfigures Nginx to serve files from `/public`.
+- **Moodle < 5.1**: A compatibility patch is applied to `publicpaths.php` to support port mapping inside the container.
+
+### Upgrading from Moodle < 5.1 to ≥ 5.1
+
+Moodle 5.1 introduces a new `/public` directory for all web-accessible files.
+If you are upgrading from 5.0 or earlier:
+
+1. **Back up critical data**:
+   - `config.php`
+   - `moodledata/` directory
+   - Database dump
+2. **Clean old files**: Remove any remaining files under `/var/www/html/` to prevent stale or conflicting code.
+3. **Restore configuration**: Copy back `config.php` and custom plugins/themes to the new codebase.
+4. **Run dependencies**: The container will automatically execute `composer install` when `/public` is detected.
 
 
 ## Usage

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -10,8 +10,8 @@ services:
         #
         # Example:
         # MOODLE_VERSION: v4.5.3
-        # MOODLE_VERSION: main # (disabled because moodle 5.1dev has many changes)
-        MOODLE_VERSION: v5.0.1
+        # MOODLE_VERSION: v5.0.1
+        MOODLE_VERSION: main
     environment:
       - SITE_URL=http://app:8080
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,8 @@ services:
         #
         # Example:
         # MOODLE_VERSION: v4.5.3
-        # MOODLE_VERSION: main # (disabled because moodle 5.1dev has many changes)
-        MOODLE_VERSION: v5.0.1
+        MOODLE_VERSION: main # (disabled because moodle 5.1dev has many changes)
+        # MOODLE_VERSION: v5.0.1
     restart: unless-stopped
     environment:
       LANG: en_US.UTF-8

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,8 @@ services:
         #
         # Example:
         # MOODLE_VERSION: v4.5.3
-        MOODLE_VERSION: main # (disabled because moodle 5.1dev has many changes)
         # MOODLE_VERSION: v5.0.1
+        MOODLE_VERSION: main
     restart: unless-stopped
     environment:
       LANG: en_US.UTF-8

--- a/rootfs/docker-entrypoint-init.d/02-configure-moodle.sh
+++ b/rootfs/docker-entrypoint-init.d/02-configure-moodle.sh
@@ -220,7 +220,7 @@ if [ ! -f "$config_file" ]; then
 fi
 
 # Detect Moodle >=5.1 (with public/ directory) — do it here, just after config.php exists
-if  [ -d /var/www/html/public ]; then
+if [ -d /var/www/html/public ]; then
     MOODLE_PUBLIC_DIR=true
     export nginx_root_directory="/var/www/html/public"
 


### PR DESCRIPTION
This pull request introduces support for Moodle 5.1 and newer, which changes the location of web-accessible files to a `/public` directory. The updates ensure compatibility with both older and newer Moodle versions by automatically detecting the directory structure and adjusting the container’s configuration and upgrade process accordingly. The documentation has been improved to guide users through upgrading and highlight important security and compatibility notes.

**Moodle 5.1+ compatibility and upgrade support:**

* The entrypoint script now detects if the `/public` directory exists (Moodle ≥5.1) and sets the `MOODLE_PUBLIC_DIR` variable accordingly, updating Nginx’s root path and running `composer install` when needed. (`rootfs/docker-entrypoint-init.d/02-configure-moodle.sh`) [[1]](diffhunk://#diff-5f1a081e01c20040ee25b43f23945b56068bc7070e276d4288045346e48c2041L10-R12) [[2]](diffhunk://#diff-5f1a081e01c20040ee25b43f23945b56068bc7070e276d4288045346e48c2041R222-R233)
* The script applies a compatibility patch to `publicpaths.php` only for Moodle versions prior to 5.1, ensuring proper port mapping inside the container. (`rootfs/docker-entrypoint-init.d/02-configure-moodle.sh`)

**Documentation improvements:**

* The `README.md` now clearly explains support for Moodle <5.1 and ≥5.1, details the upgrade process, and highlights important security notes (e.g., changing default credentials). (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L21-R25) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R39-R57)

**Configuration and environment updates:**

* The `docker-compose.yml` example now uses the `main` branch (Moodle 5.1dev) for demonstration, reflecting the latest changes and compatibility. (`docker-compose.yml`)