### PR TITLE
Update Docker base image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ARCH=
-FROM ${ARCH}erseco/alpine-php-webserver:3.20.7
+FROM ${ARCH}erseco/alpine-php-webserver:3.20
 
 LABEL maintainer="Ernesto Serrano <info@ernesto.es>"
 


### PR DESCRIPTION
This pull request updates the base image version used in the `Dockerfile` to ensure the application uses the latest stable environment.

Dependency update:

* Changed the base image in `Dockerfile` from `erseco/alpine-php-webserver:3.20.7` to `erseco/alpine-php-webserver:3.20` to use the latest minor release of the webserver image.Upgrade to latest 3.20 version instead of fix to 3.20.7