### PR TITLE
docs: publish full documentation site with Zensical + GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-          cache: pip
 
       - name: Install Zensical
         run: pip install zensical

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,67 @@
+name: docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: pip
+
+      - name: Install Zensical
+        run: pip install zensical
+
+      - name: Build site
+        run: zensical build --clean
+
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: site
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,10 +36,10 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.12'
 
       - name: Install Zensical
-        run: pip install zensical
+        run: pip install --default-timeout=120 zensical
 
       - name: Build site
         run: zensical build --clean

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 .DS_Store
 .aider*
 .env
+# Documentation site build artifacts and local Python venvs
+/site
+/.venv

--- a/README.md
+++ b/README.md
@@ -70,6 +70,73 @@ docker compose up -d
 
 For production deployments (reverse proxy, TLS, Redis, tuning, upgrades), see the [documentation site](https://erseco.github.io/alpine-moodle/).
 
+## Running Commands as Root
+
+In certain situations, you might need to run commands as `root` within your Moodle container, for example, to install additional packages. You can do this using the `docker compose exec` command with the `--user root` option:
+
+```bash
+docker compose exec --user root moodle sh
+```
+
+Example — install an extra Alpine package for debugging:
+
+```bash
+docker compose exec --user root moodle sh -c "apk update && apk add nano curl"
+```
+
+## Configuration
+
+Define the ENV variables in `docker-compose.yml`. The full reference with notes, grouping and defaults lives at <https://erseco.github.io/alpine-moodle/environment-variables/>.
+
+| Variable Name               | Default              | Description |
+|-----------------------------|----------------------|-------------|
+| `LANG`                      | `en_US.UTF-8`        | System locale. |
+| `LANGUAGE`                  | `en_US:en`           | System language fallback chain. |
+| `SITE_URL`                  | `http://localhost`   | Public site URL. Must match what users type in the browser. |
+| `REVERSEPROXY`              | `false`              | Set to `true` only if the site is intentionally served under multiple base URLs. See the [Reverse Proxy](https://erseco.github.io/alpine-moodle/reverse-proxy/) guide. |
+| `SSLPROXY`                  | `false`              | Set to `true` when a reverse proxy terminates TLS. Trusts `X-Forwarded-Proto`. |
+| `REDIS_HOST`                |                      | Hostname of the Redis instance (enables Redis sessions/cache). |
+| `REDIS_PASSWORD`            |                      | Redis password. |
+| `REDIS_USER`                |                      | Redis 6+ ACL user. Requires `REDIS_PASSWORD`. |
+| `DB_TYPE`                   | `pgsql`              | `pgsql`, `mariadb`, `mysqli` or `sqlite3`. |
+| `MOODLE_DATABASE_TYPE`      |                      | Optional override for `DB_TYPE`. Set to `sqlite3` to enable single-container dev/demo mode. |
+| `DB_HOST`                   | `postgres`           | DB container name / hostname. |
+| `DB_PORT`                   | `5432`               | Postgres=5432, MySQL/MariaDB=3306. |
+| `DB_NAME`                   | `moodle`             | Database name. |
+| `DB_USER`                   | `moodle`             | Database user. |
+| `DB_PASS`                   | `moodle`             | Database password. |
+| `DB_SQLITE_PATH`            | `/var/www/moodledata/sqlite/moodle.sqlite` | SQLite file path when using `sqlite3`. |
+| `DB_FETCHBUFFERSIZE`        |                      | Set to `0` with PgBouncer in *transaction* mode. |
+| `DB_DBHANDLEOPTIONS`        | `false`              | Set to `true` with PgBouncer pool modes that reject `SET` options. |
+| `DB_HOST_REPLICA`           |                      | Read-only replica hostname. |
+| `DB_PORT_REPLICA`           |                      | Replica port (falls back to `DB_PORT`). |
+| `DB_USER_REPLICA`           |                      | Replica user (falls back to `DB_USER`). |
+| `DB_PASS_REPLICA`           |                      | Replica password (falls back to `DB_PASS`). |
+| `DB_PREFIX`                 | `mdl_`               | DB table prefix. Do not use numeric values. |
+| `MY_CERTIFICATES`           | `none`               | Base64-encoded LDAP CA bundle. |
+| `MOODLE_EMAIL`              | `user@example.com`   | Admin email. |
+| `MOODLE_LANGUAGE`           | `en`                 | Installer language. |
+| `MOODLE_SITENAME`           | `Dockerized_Moodle`  | Full site name shown on the front page. |
+| `MOODLE_USERNAME`           | `moodleuser`         | Admin username. **Override on first boot.** |
+| `MOODLE_PASSWORD`           | `PLEASE_CHANGEME`    | Admin password. **Override on first boot.** |
+| `SMTP_HOST`                 | `smtp.gmail.com`     | SMTP server. |
+| `SMTP_PORT`                 | `587`                | SMTP port. |
+| `SMTP_USER`                 | `your_email@gmail.com` | SMTP username. |
+| `SMTP_PASSWORD`             | `your_password`      | SMTP password. |
+| `SMTP_PROTOCOL`             | `tls`                | `tls`, `ssl` or empty. |
+| `MOODLE_MAIL_NOREPLY_ADDRESS` | `noreply@localhost` | No-reply address. |
+| `MOODLE_MAIL_PREFIX`        | `[moodle]`           | Email subject prefix. |
+| `AUTO_UPDATE_MOODLE`        | `true`               | Set to `false` to skip `admin/cli/upgrade.php` on container start. |
+| `DEBUG`                     | `false`              | When `true`, enables Moodle `DEVELOPER` debug level. |
+| `client_max_body_size`      | `50M`                | Nginx max request body size. |
+| `post_max_size`             | `50M`                | PHP `post_max_size`. |
+| `upload_max_filesize`       | `50M`                | PHP `upload_max_filesize`. |
+| `max_input_vars`            | `5000`               | PHP `max_input_vars`. Keep high for Moodle course imports. |
+| `memory_limit`              | `256M`               | PHP `memory_limit`. Increase if Moosh plugin installs run out of memory. |
+| `PRE_CONFIGURE_COMMANDS`    |                      | Shell commands run before Moodle configuration. |
+| `POST_CONFIGURE_COMMANDS`   |                      | Shell commands run after Moodle configuration (great for Moosh). |
+| `RUN_CRON_TASKS`            | `true`               | Set to `false` to disable the internal `runit`-managed cron loop. |
+
 ## Key features
 
 - Compact image (~100 MB) built on [`erseco/alpine-php-webserver`](https://github.com/erseco/alpine-php-webserver)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Moodle on Alpine Linux
+# Alpine Moodle
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/erseco/alpine-moodle.svg)](https://hub.docker.com/r/erseco/alpine-moodle/)
 ![Docker Image Size](https://img.shields.io/docker/image-size/erseco/alpine-moodle)
@@ -9,383 +9,107 @@
 ![License MIT](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Build Status](https://github.com/erseco/alpine-moodle/actions/workflows/build.yml/badge.svg)
 
-A lightweight Moodle Docker image built on [Alpine Linux](https://alpinelinux.org/). (~100MB)
+A lightweight **Moodle** Docker image built on [Alpine Linux](https://alpinelinux.org/) — ~100 MB, PHP 8.3 FPM, Nginx, multi-arch, configured entirely through environment variables.
 
-Repository: https://github.com/erseco/alpine-moodle
+> 📚 **Full documentation: <https://erseco.github.io/alpine-moodle/>**
 
-**Key Features**
+The documentation site covers quick start, `docker-compose` recipes, reverse proxy setups (Traefik, Nginx, NPM, Apache, Caddy), every supported environment variable, persistence and upgrade workflows, and a troubleshooting section built from the most frequent support questions.
 
-- Built on the lightweight image https://github.com/erseco/alpine-php-webserver
-- Compact Docker image size (~100MB)
-- Uses PHP 8.3 FPM for better performance, lower cpu usage & memory footprint
-- Includes Composer.
-- Supports Moodle <5.1 and >=5.1 (detects /public directory automatically).
-- Includes Redis session handler support.
-- Includes optional container-side SQLite support for ultra-lightweight development/demo setups. The required Moodle SQLite patches ([MDL-88218](https://moodle.atlassian.net/browse/MDL-88218)) are applied automatically during the image build for supported Moodle versions (5.0+).
-- Includes [Moosh CLI](https://github.com/tmuras/moosh) for Moodle management.
-- Configurable via environment variables (see Dockerfile).
-- Support for HA installations: php-redis, php-ldap (also with self-signed certs)
-- Multi-arch support: 386, amd64, arm/v6, arm/v7, arm64, ppc64le, s390x
-- Optimized for 100 concurrent users
-- Optimized to only use resources when there's traffic (by using PHP-FPM's ondemand PM)
-- Uses `runit` instead of `supervisord` to reduce memory footprint
-- Cron jobs run every 180 seconds by runit
-- Sample `docker compose.yml` with PostgreSQL and Redis
-- Configuration via `ENV` variables
-- Services (`Nginx`, `PHP-FPM` run under a non-privileged user (`nobody`) for improved security
-- Logs are sent to container's STDOUT (`docker logs -f <container>`)
-- Extensible via pre/post configuration hooks  
-- Follows the KISS principle (Keep It Simple, Stupid) to make it easy to understand and adjust the image to your needs
+## Quick start
 
-## Important notes
+### Single container (SQLite — dev/demo only)
 
-- **Change default credentials**: Always override `MOODLE_USERNAME` and `MOODLE_PASSWORD` with secure values.
-- **SQLite mode is development/demo only**: Enable it with `MOODLE_DATABASE_TYPE=sqlite3`. It skips the external database wait logic and stores the database in `/var/www/moodledata/sqlite/moodle.sqlite` by default. Do not use this mode in production.
-- **SQLite patches**: The image automatically applies the experimental SQLite database driver patches from [ateeducacion/moodle](https://github.com/ateeducacion/moodle/pulls) during the Docker build. Patches are available for Moodle 5.0, 5.1, and main (5.2+). Older Moodle versions do not have SQLite support and the build will print a warning.
-- **Moodle ≥ 5.1**: The script automatically reconfigures Nginx to serve files from `/public`.
-- **Moodle < 5.1**: A compatibility patch is applied to `publicpaths.php` to support port mapping inside the container.
-- **PostgreSQL volumes with `postgres:alpine`**: This repository uses the floating `postgres:alpine` tag, and recent PostgreSQL 18+ image variants expect the named volume to be mounted at `/var/lib/postgresql` instead of `/var/lib/postgresql/data`. If you already have a PostgreSQL volume created with older compose files, follow the official PostgreSQL Docker image documentation in the [`PGDATA` section](https://hub.docker.com/_/postgres) before starting the updated stack to avoid confusion or accidental data reset.
-
-### Upgrading from Moodle < 5.1 to ≥ 5.1
-
-Moodle 5.1 introduces a new `/public` directory for all web-accessible files.
-If you are upgrading from 5.0 or earlier:
-
-1. **Back up critical data**:
-   - `config.php`
-   - `moodledata/` directory
-   - Database dump
-2. **Clean old files**: Remove any remaining files under `/var/www/html/` to prevent stale or conflicting code.
-3. **Restore configuration**: Copy back `config.php` and custom plugins/themes to the new codebase.
-4. **Run dependencies**: The container will automatically execute `composer install` when `/public` is detected.
-
-
-## Usage
-
-**From Docker Hub:**
 ```bash
-docker compose up
-```
-> Log in using the credentials defined by environment variables.
-
-**Ultra-lightweight SQLite demo/dev mode:**
-```bash
-docker run -p 80:8080 \
+docker run -d \
+  -p 80:8080 \
   -e MOODLE_DATABASE_TYPE=sqlite3 \
+  -e MOODLE_PASSWORD=ChangeMe123! \
   -v moodledata:/var/www/moodledata \
   erseco/alpine-moodle
 ```
-> No external database required. SQLite patches are pre-applied in the image. This mode is for development, demos, and CI smoke testing only.
 
-**From GHCR:**
-```yaml
-services:
-  moodle:
-    image: ghcr.io/erseco/alpine-moodle
-    # rest of your config
-```
+Open <http://localhost> and log in with `moodleuser` / `ChangeMe123!`.
 
-## Running Commands as Root
-
-In certain situations, you might need to run commands as `root` within your Moodle container, for example, to install additional packages. You can do this using the `docker compose exec` command with the `--user root` option. Here's how:
-
-```bash
-docker compose exec --user root moodle sh
-```
-
-## Configuration
-Define the ENV variables in docker compose.yml file
-
-| Variable Name               | Default              | Description                                                                                    |
-|-----------------------------|----------------------|------------------------------------------------------------------------------------------------|
-| LANG                        | en_US.UTF-8          |                                                                                                |
-| LANGUAGE                    | en_US:en             |                                                                                                |
-| SITE_URL                    | http://localhost     | Sets the public site url                                                                       |
-| REVERSEPROXY                | false                | See [Reverse Proxy Configuration](#reverse-proxy-configuration). |
-| SSLPROXY                    | false                | See [Reverse Proxy Configuration](#reverse-proxy-configuration).                               |
-| REDIS_HOST                  |                      | Set the host of the redis instance. Ej. redis                                         |
-| REDIS_PASSWORD              |                      | Redis server password for authentication.                                               |
-| REDIS_USER                  |                      | Redis ACL username (Redis 6+). Requires REDIS_PASSWORD (container will fail fast if set without it). |
-| DB_TYPE                     | pgsql                | mysqli - pgsql - mariadb                                                                       |
-| MOODLE_DATABASE_TYPE        |                      | Optional override for DB_TYPE. Set to `sqlite3` to enable the single-container development/demo mode. |
-| DB_HOST                     | postgres             | DB_HOST Ej. db container name                                                                  |
-| DB_PORT                     | 5432                 | Postgres=5432 - MySQL=3306                                                                     |
-| DB_NAME                     | moodle               |                                                                                                |
-| DB_USER                     | moodle               |                                                                                                |
-| DB_SQLITE_PATH              | /var/www/moodledata/sqlite/moodle.sqlite | SQLite database file path used when `MOODLE_DATABASE_TYPE=sqlite3` or `DB_TYPE=sqlite3`. |
-| DB_FETCHBUFFERSIZE          |                      | Set to 0 if using PostgresSQL poolers like PgBouncer in 'transaction' mode                     |
-| DB_DBHANDLEOPTIONS          | false                | Set to true if using PostgresSQL poolers like PgBouncer which does not support sending options |
-| DB_HOST_REPLICA             |                      | Database hostname of the read-only replica database                                            |
-| DB_PORT_REPLICA             |                      | Database port of replica, left it empty to be same as DB_PORT                                  |
-| DB_USER_REPLICA             |                      | Database login username of replica, left it empty to be same as DB_USER                        |
-| DB_PASS_REPLICA             |                      | Database login password of replica, left it empty to be same as DB_PASS                        |
-| DB_PREFIX                   | mdl_                 | Database prefix. WARNING: don't use numeric values or moodle won't start                       |
-| MY_CERTIFICATES             | none                 | Trusted LDAP certificate or chain getting through base64 encode                                |
-| MOODLE_EMAIL                | user@example.com     |                                                                                                |
-| MOODLE_LANGUAGE             | en                   |                                                                                                |
-| MOODLE_SITENAME             | New-Site             |                                                                                                |
-| MOODLE_USERNAME             | moodleuser           |                                                                                                |
-| MOODLE_PASSWORD             | PLEASE_CHANGEME      |                                                                                                |
-| SMTP_HOST                   | smtp.gmail.com       |                                                                                                |
-| SMTP_PORT                   | 587                  |                                                                                                |
-| SMTP_USER                   | your_email@gmail.com |                                                                                                |
-| SMTP_PASSWORD               | your_password        |                                                                                                |
-| SMTP_PROTOCOL               | tls                  |                                                                                                |
-| MOODLE_MAIL_NOREPLY_ADDRESS | noreply@localhost    |                                                                                                |
-| MOODLE_MAIL_PREFIX          | [moodle]             |                                                                                                |
-| AUTO_UPDATE_MOODLE          | true                 | Set to false to disable performing update of Moodle (e.g. plugins) at docker start             |
-| DEBUG                       | false                |                                                                                                |
-| client_max_body_size        | 50M                  |                                                                                                |
-| post_max_size               | 50M                  |                                                                                                |
-| upload_max_filesize         | 50M                  |                                                                                                |
-| max_input_vars              | 5000                 |                                                                                                |
-| memory_limit                | 256M                 | PHP memory limit. Increase if encountering memory errors with moosh or large operations        |
-| PRE_CONFIGURE_COMMANDS      |                      | Commands to run before starting the configuration                                              |
-| POST_CONFIGURE_COMMANDS     |                      | Commands to run after finished the configuration                                               |
-| RUN_CRON_TASKS              | true                 | Set to false to disable the moodle cron job from running automatically                         |
-
-## Reverse Proxy Configuration
-
-When using a reverse proxy (e.g., Caddy, Traefik, nginx-proxy-manager) that handles SSL termination, you might encounter issues like missing CSS or a "too many redirects" error. This is a common problem and can be solved with the correct configuration.
-
-### The Problem
-
-1.  **Missing CSS:** If you set `SITE_URL` to your internal Docker IP (e.g., `http://172.19.0.1:89`), Moodle will generate URLs with this internal address. When your browser, accessing the site via `https://moodle.example.com`, tries to load these assets, it will block them due to mixed content (trying to load `http` content on an `https` page).
-
-2.  **`ERR_TOO_MANY_REDIRECTS`:** If you set `SITE_URL` to your public HTTPS address (e.g., `https://moodle.example.com`) but don't configure the proxy settings correctly, Moodle might get confused about the protocol and enter a redirect loop.
-
-### The Solution
-
-The key is to tell Moodle that it's behind an SSL-terminating proxy. You can do this with the following environment variable settings:
-
--   `SITE_URL`: Set this to your **public, external URL** with the `https` scheme (e.g., `https://moodle.example.com`).
--   `REVERSEPROXY`: Set this to `false` for most reverse proxy setups. Set to `true` only if your Moodle site is intentionally accessible from multiple different base URLs (for example, if users access the site using different domain names or protocols). In a typical reverse proxy scenario where all users access Moodle through a single public URL, this should remain `false`. See [Moodle's documentation on reverse proxies](https://docs.moodle.org/en/Server_cluster) for more details.
--   `SSLPROXY`: Set this to `true`. This tells Moodle to trust the `X-Forwarded-Proto` header from your proxy and understand that the connection is secure, even though the internal connection to the Docker container is over HTTP.
-
-### Example Configuration
-
-Here's an example of a `docker-compose.yml` file and a `Caddyfile` for a reverse proxy setup.
-
-**`docker-compose.yml`**
+### With PostgreSQL (recommended)
 
 ```yaml
-services:
-  moodle:
-    image: erseco/alpine-moodle
-    restart: unless-stopped
-    environment:
-      SITE_URL: https://moodle.example.com
-      REVERSEPROXY: "false"
-      SSLPROXY: "true"
-      # ... other environment variables
-    # No ports need to be exposed externally, as Caddy will connect
-    # to the container directly via the Docker network.
-    volumes:
-      - moodledata:/var/www/moodledata
-      - moodlehtml:/var/www/html
-    depends_on:
-      - postgres
-
-  # ... other services (postgres, etc.)
-
-volumes:
-  moodledata:
-  moodlehtml:
-```
-
-**`Caddyfile`**
-
-```caddy
-moodle.example.com {
-    reverse_proxy moodle:8080 {
-        header_up Host {host}
-        header_up X-Forwarded-Proto {scheme}
-        header_up X-Forwarded-For {remote}
-    }
-}
-```
-
-By using this configuration, you can avoid the common pitfalls of running Moodle behind a reverse proxy. For more details, see issue [#101](https://github.com/erseco/alpine-moodle/issues/101).
-
-## Minimal docker-compose.yml example
-
-```yaml
----
 services:
   postgres:
     image: postgres:alpine
     restart: unless-stopped
     environment:
-      - POSTGRES_PASSWORD=moodle
-      - POSTGRES_USER=moodle
-      - POSTGRES_DB=moodle
+      POSTGRES_PASSWORD: moodle
+      POSTGRES_USER: moodle
+      POSTGRES_DB: moodle
     volumes:
       - postgres:/var/lib/postgresql
+
   moodle:
     image: erseco/alpine-moodle
     restart: unless-stopped
     environment:
-      MOODLE_USERNAME: moodleuser
-      MOODLE_PASSWORD: PLEASE_CHANGEME
+      MOODLE_USERNAME: admin
+      MOODLE_PASSWORD: ChangeMe123!
     ports:
-      - 80:8080
+      - "80:8080"
     volumes:
       - moodledata:/var/www/moodledata
       - moodlehtml:/var/www/html
     depends_on:
       - postgres
-volumes:
-  postgres: null
-  moodledata: null
-  moodlehtml: null
-```
-
-## SQLite single-container mode
-
-Use SQLite when you want the lightest possible local setup and do not want to run PostgreSQL or MariaDB alongside Moodle.
-
-```yaml
-services:
-  moodle:
-    image: erseco/alpine-moodle
-    restart: unless-stopped
-    environment:
-      MOODLE_DATABASE_TYPE: sqlite3
-      MOODLE_USERNAME: moodleuser
-      MOODLE_PASSWORD: PLEASE_CHANGEME
-    ports:
-      - 8080:8080
-    volumes:
-      - moodledata:/var/www/moodledata
 
 volumes:
-  moodledata: null
+  postgres:
+  moodledata:
+  moodlehtml:
 ```
-
-Notes:
-
-- SQLite mode automatically skips external database dependency checks.
-- The SQLite database file defaults to `/var/www/moodledata/sqlite/moodle.sqlite`.
-- Existing PostgreSQL/MariaDB configurations remain the default and are unchanged.
-- The required Moodle SQLite patches ([MDL-88218](https://moodle.atlassian.net/browse/MDL-88218)) are applied automatically during the image build for Moodle 5.0, 5.1, and main/5.2+. Older versions will print a build-time warning and sqlite3 mode will not be available.
-
-## Advanced Features
-
-### 1. Using Moosh CLI
-
-This image includes [Moosh](https://github.com/tmuras/moosh) — a powerful CLI tool to manage Moodle installations. You can invoke any Moosh command using:
 
 ```bash
-docker compose exec moodle moosh <command>
+docker compose up -d
 ```
 
-Examples:
+For production deployments (reverse proxy, TLS, Redis, tuning, upgrades), see the [documentation site](https://erseco.github.io/alpine-moodle/).
 
-#### Upgrade plugin list (required to install)
-```bash
-docker compose exec moodle moosh plugin-list
-```
+## Key features
 
-#### Install a Plugin by Name
-```bash
-docker compose exec moodle moosh plugin-install mod_attendance
-```
+- Compact image (~100 MB) built on [`erseco/alpine-php-webserver`](https://github.com/erseco/alpine-php-webserver)
+- PHP 8.3 FPM with `ondemand` process manager — idles near-zero CPU
+- PostgreSQL, MariaDB/MySQL **or** SQLite (single-container dev mode)
+- Optional Redis session handler
+- Supports Moodle 4.x, 5.0, 5.1+ (auto-detects `/public` layout) and `main`
+- Multi-arch: `amd64`, `arm64`, `arm/v7`, `arm/v6`, `386`, `ppc64le`, `s390x`
+- [Moosh CLI](https://github.com/tmuras/moosh) bundled for automation
+- Pre/post configuration hooks (`PRE_CONFIGURE_COMMANDS`, `POST_CONFIGURE_COMMANDS`)
+- Runs as the non-privileged `nobody` user
+- Logs to `stdout` / `stderr` — just `docker logs -f`
+- Internal cron via `runit` (configurable, or run it externally)
 
-> You can force the installation of unsupported plugins with the `--force` option.
-> 
-> If you encounter memory errors during plugin installation, increase the `memory_limit` environment variable (default: 256M) in your docker-compose.yml. For example: `memory_limit: 512M` 
+## Registries
 
-> NOTE:[There is a bug in moosh and the first installation is not working](https://github.com/tmuras/moosh/issues/520), so we recommend calling again the install function with the `--delete` flag option or use the `module-reinstall` option: eg: `docker compose exec moodle moosh plugin-install --delete theme_almondb` or call `docker compose exec moodle moosh module-reinstall theme_almondb`
-#### Backup a Course
+- Docker Hub: `erseco/alpine-moodle`
+- GitHub Container Registry: `ghcr.io/erseco/alpine-moodle`
 
-Backup course with provided id. By default, logs and grade histories are excluded.
+## Documentation
 
-Example: Backup course id=3 into default .mbz file in `/opt/moosh/` directory from container:
+The full, searchable documentation lives at **<https://erseco.github.io/alpine-moodle/>**:
 
-```bash
-docker compose exec moodle moosh course-backup 3
-```
+- [Quick Start](https://erseco.github.io/alpine-moodle/quick-start/)
+- [Docker Compose examples](https://erseco.github.io/alpine-moodle/docker-compose/)
+- [Reverse proxy guides](https://erseco.github.io/alpine-moodle/reverse-proxy/) (Traefik, Nginx, NPM, Apache, Caddy)
+- [Environment variables reference](https://erseco.github.io/alpine-moodle/environment-variables/)
+- [Persistence & volumes](https://erseco.github.io/alpine-moodle/persistence/)
+- [Configuration & Moosh](https://erseco.github.io/alpine-moodle/configuration/)
+- [SQLite single-container mode](https://erseco.github.io/alpine-moodle/sqlite/)
+- [Upgrading](https://erseco.github.io/alpine-moodle/upgrading/)
+- [Troubleshooting](https://erseco.github.io/alpine-moodle/troubleshooting/)
+- [FAQ](https://erseco.github.io/alpine-moodle/faq/)
 
-#### Create a User
+## Contributing
 
-Create a new Moodle user. Provide one or more arguments to create one or more users.
+Issues and pull requests are welcome: <https://github.com/erseco/alpine-moodle/issues>.
 
-Example: create user "testuser" with the all the optional values
+Documentation sources live under [`docs/`](docs/) and are built with [Zensical](https://zensical.org/) via the `docs.yml` GitHub Actions workflow.
 
+## License
 
-```bash
-docker compose exec moodle moosh user-create --password pass --email me@example.com --digest 2 --city Valverde --country ES --institution "IES Garoé" --department "Technology" --firstname "first name" --lastname name testuser
-```
-
-#### Delete a User
-
-Delete user(s) from Moodle. Provide one or more usernames as arguments.
-Example: delete user testuser
-
-```bash
-docker compose exec moodle moosh user-delete testuser
-```
-
-These examples can be included directly in `POST_CONFIGURE_COMMANDS` to automate plugin installation, backups, or any Moosh-supported functionality.
-
-Using Moosh promotes the DRY (Don't Repeat Yourself) principle and leverages a powerful toolset for Moodle administration.
-
-For the full list of commands, visit: https://moosh-online.com/commands/
-
-
-### 2. Pre/Post Configuration Hooks
-
-You can define commands to be executed before and after the configuration of Moodle using the `PRE_CONFIGURE_COMMANDS` and `POST_CONFIGURE_COMMANDS` environment variables. These can be useful for tasks such as installing additional packages or running scripts.
-
-```yaml
-environment:
-  PRE_CONFIGURE_COMMANDS: "cat config-dist.php"
-  POST_CONFIGURE_COMMANDS: |
-    moosh plugin-list
-    moosh plugin-install --delete theme_almondb
-    moosh plugin-install --delete theme_almondb
-```
-
-### 3. Specifying a Moodle Version
-
-Calling `docker compose build` uses the latest version of Moodle from the main branch. If you need to use a specific Moodle version, you can specify it using the `MOODLE_VERSION` build argument.
-
-To use a specific version, edit the build section for the moodle service in your docker compose.yml file:
-
-```yaml
-moodle:
-  image: erseco/alpine-moodle
-  build:
-    context: .
-    args:
-      MOODLE_VERSION: v4.5.3  # Replace with your desired version
-```
-You can find the list of available version tags at: https://github.com/moodle/moodle/tags
-
-
-### 4. Enabling Test Scenario Generator
-
-Moodle includes a tool to create [test scenarios](https://moodledev.io/general/development/tools/generator#create-a-testing-scenario-using-behat-generators) under `Admin > Development > Create testing scenarios`. To enable it, run the following command, or add it in `POST_CONFIGURE_COMMANDS`:
-
-```bash
-php admin/tool/generator/cli/runtestscenario.php
-```
-
-This tool allows generating all necessary elements for manual testing using `.feature` file syntax.
-
-## Maintenance Tips
-
-**Install Additional Alpine Packages (as root):**
-```bash
-docker compose exec --user root moodle sh -c "apk update && apk add nano"
-```
-
-**Manual Database Upgrade:**
-```bash
-docker compose exec moodle php admin/cli/upgrade.php
-```
-
-**Access Logs:**
-```bash
-docker compose logs -f moodle
-```
+[MIT](LICENSE)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,152 @@
+# Configuration
+
+Beyond the basic environment variables, the image offers several extension points for customising Moodle without rebuilding.
+
+## Pre / post configuration hooks
+
+Use `PRE_CONFIGURE_COMMANDS` and `POST_CONFIGURE_COMMANDS` to run arbitrary shell on every container start, before and after Moodle's configuration is applied.
+
+```yaml
+environment:
+  PRE_CONFIGURE_COMMANDS: |
+    echo "Running pre-configure step..."
+
+  POST_CONFIGURE_COMMANDS: |
+    moosh plugin-list
+    moosh plugin-install --delete mod_attendance
+    moosh plugin-install --delete theme_almondb
+    php admin/cli/cfg.php --name=enableblogs --set=1
+```
+
+!!! tip "Idempotency"
+    These hooks run **every time** the container starts. Use commands that can be re-run safely (the `--delete` flag on `moosh plugin-install` is recommended because of [a known Moosh bug](https://github.com/tmuras/moosh/issues/520) where the first install silently fails).
+
+## Moosh CLI
+
+[Moosh](https://github.com/tmuras/moosh) is bundled at `/opt/moosh` and exposed on the `PATH` as `moosh`.
+
+```bash
+docker compose exec moodle moosh plugin-list
+docker compose exec moodle moosh plugin-install mod_attendance
+docker compose exec moodle moosh user-create --password pass --email me@example.com \
+  --firstname "Jane" --lastname "Doe" janedoe
+docker compose exec moodle moosh course-backup 3
+```
+
+Full command reference: <https://moosh-online.com/commands/>
+
+!!! warning "Memory limit errors from Moosh"
+    Moosh plugin operations can exhaust PHP's memory limit on large plugins ([#119](https://github.com/erseco/alpine-moodle/issues/119)):
+
+    ```
+    PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted in
+    /opt/moosh/Moosh/Command/Generic/Plugin/PluginInstall.php on line 237
+    ```
+
+    Raise `memory_limit` in the container environment:
+
+    ```yaml
+    environment:
+      memory_limit: 512M
+    ```
+
+## Moodle CLI
+
+Everything under `admin/cli/` works as usual:
+
+```bash
+docker compose exec moodle php admin/cli/cfg.php --name=debug --set=32767
+docker compose exec moodle php admin/cli/upgrade.php --non-interactive
+docker compose exec moodle php admin/cli/purge_caches.php
+docker compose exec moodle php admin/cli/maintenance.php --enable
+```
+
+## Redis sessions & caching
+
+Set `REDIS_HOST` and (optionally) `REDIS_PASSWORD` / `REDIS_USER`:
+
+```yaml
+services:
+  redis:
+    image: redis:alpine
+
+  moodle:
+    environment:
+      REDIS_HOST: redis
+      # REDIS_PASSWORD: supersecret
+      # REDIS_USER: moodle
+```
+
+On start the container runs `admin/cli/configure_redis.php` and writes the Redis session handler into `config.php`. Unset `REDIS_HOST` to go back to file sessions.
+
+!!! note
+    `REDIS_USER` requires Redis 6+ ACLs *and* `REDIS_PASSWORD`. The container fails fast if you set a user without a password.
+
+## LDAP with custom certificates
+
+The image ships with `php-ldap`. To trust a custom CA (for example your corporate LDAPS):
+
+```bash
+base64 -w0 my-ca.pem
+```
+
+Then pass the result as `MY_CERTIFICATES`:
+
+```yaml
+environment:
+  MY_CERTIFICATES: "LS0tLS1CRUdJTi...LS0tLS0="
+```
+
+The value is decoded into `/etc/openldap/my-certificates/extra.pem` at startup and picked up by `openldap`'s client libraries.
+
+See [#122](https://github.com/erseco/alpine-moodle/issues/122) for context.
+
+## Running commands as root
+
+The container runs as `nobody`. If you need to install packages for debugging, re-enter as root:
+
+```bash
+docker compose exec --user root moodle sh -c "apk update && apk add nano curl"
+```
+
+## Custom `config.php` tweaks
+
+The startup script enforces the settings it manages (wwwroot, DB, proxy flags, Redis). You can still add custom `$CFG` values through `POST_CONFIGURE_COMMANDS` using sed or PHP, or by mounting a small snippet that `require`s at the end of `config.php`. Anything you write during runtime is lost on the next start unless it lives inside a persistent volume.
+
+## Pinning a Moodle version at build time
+
+```yaml
+services:
+  moodle:
+    build:
+      context: .
+      args:
+        MOODLE_VERSION: v5.0.2
+```
+
+Or use a pre-built tag:
+
+```yaml
+services:
+  moodle:
+    image: erseco/alpine-moodle:v5.0.2
+```
+
+Available Moodle tags: <https://github.com/moodle/moodle/tags>
+
+## Disabling the internal cron
+
+By default `runit` runs `admin/cli/cron.php` every 180 seconds inside the container ([#98](https://github.com/erseco/alpine-moodle/issues/98)). If you orchestrate cron externally (e.g. a Kubernetes CronJob), disable the internal loop:
+
+```yaml
+environment:
+  RUN_CRON_TASKS: "false"
+```
+
+## Test scenario generator
+
+```bash
+docker compose exec moodle php admin/tool/generator/cli/runtestscenario.php
+```
+
+Or add it to `POST_CONFIGURE_COMMANDS` to seed a test site on every startup.

--- a/docs/docker-compose.md
+++ b/docs/docker-compose.md
@@ -1,0 +1,233 @@
+# Docker Compose Examples
+
+Practical `docker-compose.yml` stacks for common deployment shapes. Pick the one that matches your environment and adapt the passwords, domain, and ports.
+
+## Minimal local deployment
+
+Single PostgreSQL, no Redis, no reverse proxy. Good for evaluation and local development.
+
+```yaml
+services:
+  postgres:
+    image: postgres:alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_PASSWORD: moodle
+      POSTGRES_USER: moodle
+      POSTGRES_DB: moodle
+    volumes:
+      - postgres:/var/lib/postgresql
+
+  moodle:
+    image: erseco/alpine-moodle
+    restart: unless-stopped
+    environment:
+      SITE_URL: http://localhost
+      MOODLE_USERNAME: admin
+      MOODLE_PASSWORD: ChangeMe123!
+    ports:
+      - "80:8080"
+    volumes:
+      - moodledata:/var/www/moodledata
+      - moodlehtml:/var/www/html
+    depends_on:
+      - postgres
+
+volumes:
+  postgres:
+  moodledata:
+  moodlehtml:
+```
+
+## Persistent deployment with Redis
+
+Adds Redis session handling for better performance and shared sessions across replicas.
+
+```yaml
+services:
+  postgres:
+    image: postgres:alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_PASSWORD: moodle
+      POSTGRES_USER: moodle
+      POSTGRES_DB: moodle
+    volumes:
+      - postgres:/var/lib/postgresql
+
+  redis:
+    image: redis:alpine
+    restart: unless-stopped
+
+  moodle:
+    image: erseco/alpine-moodle
+    restart: unless-stopped
+    environment:
+      SITE_URL: https://moodle.example.com
+      DB_HOST: postgres
+      DB_USER: moodle
+      DB_PASS: moodle
+      DB_NAME: moodle
+      REDIS_HOST: redis
+      MOODLE_USERNAME: admin
+      MOODLE_PASSWORD: ChangeMe123!
+      MOODLE_SITENAME: "My Moodle"
+      MOODLE_EMAIL: admin@example.com
+      SSLPROXY: "true"
+    ports:
+      - "8080:8080"
+    volumes:
+      - moodledata:/var/www/moodledata
+      - moodlehtml:/var/www/html
+    depends_on:
+      - postgres
+      - redis
+
+volumes:
+  postgres:
+  moodledata:
+  moodlehtml:
+```
+
+## Deployment behind a reverse proxy
+
+The reverse proxy terminates TLS and forwards to Moodle over the internal Docker network. The container does **not** need to expose any port to the host.
+
+```yaml
+services:
+  postgres:
+    image: postgres:alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_PASSWORD: moodle
+      POSTGRES_USER: moodle
+      POSTGRES_DB: moodle
+    volumes:
+      - postgres:/var/lib/postgresql
+
+  moodle:
+    image: erseco/alpine-moodle
+    restart: unless-stopped
+    environment:
+      SITE_URL: https://moodle.example.com
+      SSLPROXY: "true"
+      REVERSEPROXY: "false"
+      DB_HOST: postgres
+      DB_USER: moodle
+      DB_PASS: moodle
+      DB_NAME: moodle
+      MOODLE_USERNAME: admin
+      MOODLE_PASSWORD: ChangeMe123!
+    volumes:
+      - moodledata:/var/www/moodledata
+      - moodlehtml:/var/www/html
+    networks:
+      - proxy
+      - default
+    depends_on:
+      - postgres
+
+volumes:
+  postgres:
+  moodledata:
+  moodlehtml:
+
+networks:
+  proxy:
+    external: true
+```
+
+See [Reverse Proxy](reverse-proxy.md) for complete examples for Traefik, Nginx, Nginx Proxy Manager, Apache and Caddy.
+
+## MariaDB instead of PostgreSQL
+
+```yaml
+services:
+  mariadb:
+    image: mariadb:lts
+    restart: unless-stopped
+    environment:
+      MARIADB_ROOT_PASSWORD: rootpw
+      MARIADB_DATABASE: moodle
+      MARIADB_USER: moodle
+      MARIADB_PASSWORD: moodle
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --innodb-file-per-table=1
+    volumes:
+      - mariadb:/var/lib/mysql
+
+  moodle:
+    image: erseco/alpine-moodle
+    restart: unless-stopped
+    environment:
+      DB_TYPE: mariadb
+      DB_HOST: mariadb
+      DB_PORT: 3306
+      DB_NAME: moodle
+      DB_USER: moodle
+      DB_PASS: moodle
+      MOODLE_USERNAME: admin
+      MOODLE_PASSWORD: ChangeMe123!
+    ports:
+      - "80:8080"
+    volumes:
+      - moodledata:/var/www/moodledata
+      - moodlehtml:/var/www/html
+    depends_on:
+      - mariadb
+
+volumes:
+  mariadb:
+  moodledata:
+  moodlehtml:
+```
+
+!!! note "Moodle requires specific MySQL/MariaDB settings"
+    Moodle expects `utf8mb4`, a large row format and `innodb_file_per_table`. The command overrides above cover the most common requirements.
+
+## SQLite single-container mode
+
+```yaml
+services:
+  moodle:
+    image: erseco/alpine-moodle
+    restart: unless-stopped
+    environment:
+      MOODLE_DATABASE_TYPE: sqlite3
+      MOODLE_USERNAME: admin
+      MOODLE_PASSWORD: ChangeMe123!
+    ports:
+      - "8080:8080"
+    volumes:
+      - moodledata:/var/www/moodledata
+
+volumes:
+  moodledata:
+```
+
+See the [SQLite Mode](sqlite.md) page for the full story.
+
+## Pinning a Moodle version
+
+You can run any Moodle tag available in the upstream repository:
+
+```yaml
+services:
+  moodle:
+    image: erseco/alpine-moodle:v5.0.2
+```
+
+Or build the image yourself for a specific Moodle version:
+
+```yaml
+services:
+  moodle:
+    build:
+      context: .
+      args:
+        MOODLE_VERSION: v5.0.2
+```
+
+Available tags: <https://github.com/moodle/moodle/tags>

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,0 +1,107 @@
+# Environment Variables
+
+Every setting exposed by `erseco/alpine-moodle`. Defaults come from the `Dockerfile` and are applied unless you override them in `docker run`, `docker-compose.yml`, or your orchestration tool.
+
+## Site
+
+| Variable           | Default              | Description |
+|--------------------|----------------------|-------------|
+| `SITE_URL`         | `http://localhost`   | Public URL of the site. Becomes `$CFG->wwwroot`. Must match what users type in the browser. |
+| `MOODLE_SITENAME`  | `Dockerized_Moodle`  | Full name shown on the Moodle front page. |
+| `MOODLE_LANGUAGE`  | `en`                 | Installer language. Sets `--lang` on `admin/cli/install.php`. |
+| `LANG`             | `en_US.UTF-8`        | System locale. |
+| `LANGUAGE`         | `en_US:en`           | System language fallback chain. |
+
+## Admin user
+
+| Variable           | Default           | Description |
+|--------------------|-------------------|-------------|
+| `MOODLE_USERNAME`  | `moodleuser`      | Initial admin username. |
+| `MOODLE_PASSWORD`  | `PLEASE_CHANGEME` | Initial admin password. **Always override.** |
+| `MOODLE_EMAIL`     | `user@example.com`| Admin email address. |
+
+!!! warning
+    If the container finds an existing install, these values are re-applied to the admin user on every start via `admin/cli/update_admin_user.php`. Keep them in sync with your secret store.
+
+## Database — primary
+
+| Variable                | Default   | Description |
+|-------------------------|-----------|-------------|
+| `DB_TYPE`               | `pgsql`   | `pgsql`, `mariadb`, `mysqli` or `sqlite3`. |
+| `MOODLE_DATABASE_TYPE`  | *(empty)* | Optional override for `DB_TYPE`. Set to `sqlite3` to enable the single-container mode. |
+| `DB_HOST`               | `postgres`| DB hostname (service name on the Docker network). |
+| `DB_PORT`               | `5432`    | 5432 for PostgreSQL, 3306 for MariaDB/MySQL. |
+| `DB_NAME`               | `moodle`  | Database name. |
+| `DB_USER`               | `moodle`  | Database user. |
+| `DB_PASS`               | `moodle`  | Database password. |
+| `DB_PREFIX`             | `mdl_`    | Table prefix. Must be non-numeric. |
+| `DB_SQLITE_PATH`        | `/var/www/moodledata/sqlite/moodle.sqlite` | SQLite file path. Must resolve inside `/var/www/moodledata/`. |
+| `DB_FETCHBUFFERSIZE`    | *(empty)* | Set to `0` when using PgBouncer in *transaction* mode. |
+| `DB_DBHANDLEOPTIONS`    | `false`   | Set to `true` with PgBouncer (pool modes that reject `SET` options). |
+
+## Database — read replica (optional)
+
+| Variable              | Default   | Description |
+|-----------------------|-----------|-------------|
+| `DB_HOST_REPLICA`     | *(empty)* | Enables the read-only replica if set. |
+| `DB_PORT_REPLICA`     | *(empty)* | Falls back to `DB_PORT`. |
+| `DB_USER_REPLICA`     | *(empty)* | Falls back to `DB_USER`. |
+| `DB_PASS_REPLICA`     | *(empty)* | Falls back to `DB_PASS`. |
+
+## Redis (optional)
+
+| Variable         | Default   | Description |
+|------------------|-----------|-------------|
+| `REDIS_HOST`     | *(empty)* | When set, enables the Redis session handler and cache store. |
+| `REDIS_PASSWORD` | *(empty)* | Redis password. |
+| `REDIS_USER`     | *(empty)* | Redis 6+ ACL user. Requires `REDIS_PASSWORD` or the container aborts at startup. |
+
+## Reverse proxy / TLS
+
+| Variable       | Default | Description |
+|----------------|---------|-------------|
+| `REVERSEPROXY` | `false` | Set to `true` only if the site is intentionally served from multiple base URLs. |
+| `SSLPROXY`     | `false` | Set to `true` when a reverse proxy terminates TLS. Trusts `X-Forwarded-Proto`. |
+| `MY_CERTIFICATES` | `none` | Base64-encoded trusted certificate bundle installed into the LDAP truststore (`/etc/openldap/my-certificates/extra.pem`). Use `none` to disable. |
+
+See [Reverse Proxy](reverse-proxy.md) for concrete examples.
+
+## Email / SMTP
+
+| Variable                       | Default                | Description |
+|--------------------------------|------------------------|-------------|
+| `SMTP_HOST`                    | `smtp.gmail.com`       | SMTP server hostname. |
+| `SMTP_PORT`                    | `587`                  | SMTP server port. |
+| `SMTP_USER`                    | `your_email@gmail.com` | SMTP username. |
+| `SMTP_PASSWORD`                | `your_password`        | SMTP password. |
+| `SMTP_PROTOCOL`                | `tls`                  | `tls`, `ssl` or empty. |
+| `MOODLE_MAIL_NOREPLY_ADDRESS`  | `noreply@localhost`    | Used as `noreplyaddress`. |
+| `MOODLE_MAIL_PREFIX`           | `[moodle]`             | Email subject prefix. |
+
+## PHP / web server tuning
+
+| Variable               | Default | Description |
+|------------------------|---------|-------------|
+| `client_max_body_size` | `50M`   | Nginx max request body size. |
+| `post_max_size`        | `50M`   | PHP `post_max_size`. |
+| `upload_max_filesize`  | `50M`   | PHP `upload_max_filesize`. |
+| `max_input_vars`       | `5000`  | PHP `max_input_vars`. Keep high for Moodle course imports. |
+| `memory_limit`         | `256M`  | PHP `memory_limit`. Increase to `512M` or more for big plugin installs / Moosh operations ([#119](https://github.com/erseco/alpine-moodle/issues/119)). |
+
+## Operational
+
+| Variable                 | Default | Description |
+|--------------------------|---------|-------------|
+| `AUTO_UPDATE_MOODLE`     | `true`  | If `false`, skip the automatic `admin/cli/upgrade.php` on container start. |
+| `RUN_CRON_TASKS`         | `true`  | Set to `false` to disable the internal `runit`-managed cron loop. Useful when you run cron externally. |
+| `DEBUG`                  | `false` | When `true`, enables Moodle `DEVELOPER` debug level and `debugdisplay`. |
+| `PRE_CONFIGURE_COMMANDS` | *(empty)* | Shell commands run **before** Moodle configuration. |
+| `POST_CONFIGURE_COMMANDS`| *(empty)* | Shell commands run **after** Moodle configuration (great for Moosh). |
+
+## Build-time argument
+
+| Build ARG        | Default | Description |
+|------------------|---------|-------------|
+| `MOODLE_VERSION` | `main`  | Upstream Moodle tag to install (e.g. `v5.0.2`, `v4.5.7`). `main` installs the current development branch. |
+
+Full list of available Moodle tags: <https://github.com/moodle/moodle/tags>

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,100 @@
+# FAQ
+
+Short answers to recurring questions from the issue tracker.
+
+## Which database should I use?
+
+PostgreSQL. It is the default, it is the combination that receives the most CI coverage in this repository, and it is the best supported database by upstream Moodle. MariaDB works too, SQLite is development-only.
+
+## Which port does the container listen on?
+
+**8080**, inside the container. Always map or proxy to `8080`, not `80`. Publishing on the host with `-p 80:8080` exposes the public port 80 bound to the container's 8080.
+
+## Can I serve Moodle from a sub-path like `https://example.com/mylms/`?
+
+No. Moodle does not support subpath deployment without patching. Use a subdomain such as `moodle.example.com`. Related: [#127](https://github.com/erseco/alpine-moodle/issues/127).
+
+## How do I change the admin password after installation?
+
+The container re-applies `MOODLE_USERNAME` / `MOODLE_PASSWORD` on every start via `admin/cli/update_admin_user.php`. Change the environment variable and restart:
+
+```bash
+docker compose up -d --force-recreate moodle
+```
+
+Or do it manually:
+
+```bash
+docker compose exec moodle php admin/cli/reset_password.php --username=admin --password=NewPass123!
+```
+
+## Can I run multiple Moodle instances on the same host?
+
+Yes. Give each stack its own project directory (so `docker compose` namespaces the volumes) and map different host ports — for example `8080:8080` and `8081:8080`. Use one reverse proxy to terminate TLS and route by hostname.
+
+## How do I install a plugin?
+
+Use Moosh, either interactively:
+
+```bash
+docker compose exec moodle moosh plugin-install --delete mod_attendance
+```
+
+or declaratively via `POST_CONFIGURE_COMMANDS` so the plugin is (re)installed on every start.
+
+The `--delete` flag is recommended because of a [known Moosh bug](https://github.com/tmuras/moosh/issues/520) where the first install can silently fail.
+
+## Can I disable the internal cron?
+
+Yes — set `RUN_CRON_TASKS=false`. You are then responsible for running `admin/cli/cron.php` externally. Related: [#98](https://github.com/erseco/alpine-moodle/issues/98).
+
+## Can I skip the automatic Moodle upgrade on boot?
+
+Yes — set `AUTO_UPDATE_MOODLE=false`. The container will start without running `admin/cli/upgrade.php`; you must run it yourself before letting users back in.
+
+## Which architectures are supported?
+
+`amd64`, `arm64`, `arm/v7`, `arm/v6`, `386`, `ppc64le`, `s390x`. Pull `erseco/alpine-moodle` on any of them and Docker will fetch the right variant.
+
+## Does the image include Redis / PostgreSQL / MariaDB?
+
+No. The image only contains Moodle, PHP 8.3, Nginx, Moosh and supporting tools. External services (database, Redis) must run in their own containers. See [Docker Compose](docker-compose.md) for ready-made stacks.
+
+## Can I mount my own `config.php`?
+
+You can, but the startup script will try to update its managed keys (wwwroot, dbtype, dbhost, proxy flags, Redis handler) in place. Mount a writable `config.php` and don't add anything to keys the container owns. For custom `$CFG` flags, add them near the bottom of the file.
+
+## How do I enable developer debug output?
+
+Set `DEBUG=true`. This flips `debug` and `debugdisplay` to the `DEVELOPER` preset. Related: [#25](https://github.com/erseco/alpine-moodle/issues/25).
+
+## Why doesn't the image auto-detect the public hostname?
+
+Because there is no reliable way to do it. Browser requests can come through any number of proxies, tunnels, or load balancers. Moodle needs to know its canonical URL up front, which is why `SITE_URL` is the most important variable in this image.
+
+## What's the default admin login?
+
+`moodleuser` / `PLEASE_CHANGEME`. **You must override both** on first boot. The defaults exist only so the installer has something to pass to the CLI.
+
+## Where do logs go?
+
+To `stdout` / `stderr`, so `docker logs` and `docker compose logs` just work. Nginx access logs, PHP-FPM logs, and the Moodle bootstrap scripts all converge on the container's standard output.
+
+## Where are uploads stored?
+
+In `/var/www/moodledata/`. Mount a volume there to persist them. See [Persistence & Volumes](persistence.md).
+
+## What happens on the first boot?
+
+1. The container waits for the database (unless SQLite).
+2. It runs any `PRE_CONFIGURE_COMMANDS`.
+3. It generates a fresh `config.php` and calls `admin/cli/install.php --skip-database`.
+4. For Moodle 5.1+, it runs `composer install` against `/var/www/html`.
+5. It writes the database schema with `admin/cli/install_database.php` (unless the database is already installed — in that case it upgrades instead).
+6. It applies all the Moodle `cfg.php` tweaks (SMTP, paths, debug).
+7. It runs any `POST_CONFIGURE_COMMANDS`.
+8. It starts Nginx, PHP-FPM and the cron loop under `runit`.
+
+## Can I contribute?
+
+Yes — open an issue or a PR at <https://github.com/erseco/alpine-moodle>. Documentation PRs are very welcome; the docs site lives under `docs/` and is built with Zensical.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,63 @@
+# Alpine Moodle
+
+A lightweight **Moodle** Docker image built on [Alpine Linux](https://alpinelinux.org/).
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/erseco/alpine-moodle.svg)](https://hub.docker.com/r/erseco/alpine-moodle/)
+![Docker Image Size](https://img.shields.io/docker/image-size/erseco/alpine-moodle)
+![License MIT](https://img.shields.io/badge/license-MIT-blue.svg)
+
+## What is this image?
+
+`erseco/alpine-moodle` packages Moodle into a single, small (~100 MB) container based on
+[`erseco/alpine-php-webserver`](https://github.com/erseco/alpine-php-webserver). It runs
+Nginx + PHP-FPM under a non-privileged user, includes [Moosh CLI](https://github.com/tmuras/moosh),
+and is configured entirely through environment variables.
+
+Highlights:
+
+- PHP 8.3 FPM with `ondemand` process manager — low idle footprint
+- Works with PostgreSQL, MariaDB/MySQL, or SQLite (single-container dev mode)
+- Optional Redis session handler for HA deployments
+- Supports Moodle **4.x**, **5.0**, **5.1** (with `/public` directory) and `main`
+- Multi-arch images: `amd64`, `arm64`, `arm/v7`, `arm/v6`, `386`, `ppc64le`, `s390x`
+- Internal cron via `runit` (configurable)
+- Logs go straight to `docker logs`
+- Extensible via pre/post configuration hooks and `POST_CONFIGURE_COMMANDS`
+
+## Where to start
+
+<div class="grid cards" markdown>
+
+- :material-rocket-launch: **[Quick Start](quick-start.md)** — get a Moodle instance running in under a minute.
+- :material-docker: **[Docker Compose](docker-compose.md)** — practical stacks for dev, production and proxied setups.
+- :material-shield-lock: **[Reverse Proxy](reverse-proxy.md)** — Traefik, Nginx, NPM, Apache, Caddy recipes.
+- :material-database: **[Environment Variables](environment-variables.md)** — every supported knob, with defaults.
+- :material-harddisk: **[Persistence & Volumes](persistence.md)** — what to mount and what to back up.
+- :material-update: **[Upgrading](upgrading.md)** — how to move between Moodle versions safely.
+- :material-lightbulb-on: **[Troubleshooting](troubleshooting.md)** — solutions to the most common deployment issues.
+- :material-help-circle: **[FAQ](faq.md)** — short answers to recurring questions.
+
+</div>
+
+## Minimal example
+
+```bash
+docker run -d \
+  -p 80:8080 \
+  -e MOODLE_DATABASE_TYPE=sqlite3 \
+  -e MOODLE_PASSWORD=ChangeMe123! \
+  -v moodledata:/var/www/moodledata \
+  erseco/alpine-moodle
+```
+
+Open <http://localhost> and log in with `moodleuser` / `ChangeMe123!`.
+
+!!! warning "SQLite is for development and demos only"
+    Use PostgreSQL or MariaDB for any real deployment. See [Docker Compose](docker-compose.md) for production-grade examples.
+
+## Project links
+
+- Source code: <https://github.com/erseco/alpine-moodle>
+- Docker Hub: <https://hub.docker.com/r/erseco/alpine-moodle>
+- GitHub Container Registry: `ghcr.io/erseco/alpine-moodle`
+- Issue tracker: <https://github.com/erseco/alpine-moodle/issues>

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -1,0 +1,135 @@
+# Persistence & Volumes
+
+Moodle stores state in three different places. Choosing which ones to persist determines how your backups work and how painful upgrades are.
+
+## What each path contains
+
+| Path inside the container | Contents | Should you persist it? |
+|---------------------------|----------|------------------------|
+| `/var/www/html`           | Moodle PHP code + `config.php` + installed plugins/themes | **Depends** — see below |
+| `/var/www/moodledata`     | User-generated data: file uploads, sessions, cache, question attachments, backups | **Yes, always** |
+| Database volume (Postgres / MariaDB) | Courses, users, grades, config, everything metadata | **Yes, always** |
+
+## Recommended setup
+
+```yaml
+services:
+  postgres:
+    image: postgres:alpine
+    volumes:
+      - postgres:/var/lib/postgresql      # (1)
+
+  moodle:
+    image: erseco/alpine-moodle
+    volumes:
+      - moodledata:/var/www/moodledata    # (2)
+      - moodlehtml:/var/www/html          # (3)
+
+volumes:
+  postgres:
+  moodledata:
+  moodlehtml:
+```
+
+1. Database files. Back up with `pg_dump`. See the note on PostgreSQL 18+ below.
+2. Uploads, sessions, file storage. Back up with a cold copy or `tar`.
+3. Moodle code, plugins, themes and `config.php`. See the upgrade tradeoff below.
+
+## The `moodlehtml` tradeoff
+
+Mounting `/var/www/html` as a named volume preserves installed plugins, custom themes, and `config.php` between container restarts. **The cost is that upgrading Moodle by changing the image tag alone does not work**, because the old code is kept on the volume ([#102](https://github.com/erseco/alpine-moodle/issues/102), [#103](https://github.com/erseco/alpine-moodle/issues/103)).
+
+You have two patterns:
+
+=== "Persistent `moodlehtml` (default)"
+
+    Pros: plugins and themes survive restarts, `config.php` keeps customisations.
+
+    Cons: to upgrade Moodle you need to remove the `moodlehtml` volume, start the new image, then re-apply plugins/themes. Always back up first.
+
+    ```bash
+    docker compose down
+    docker volume rm <project>_moodlehtml
+    docker compose pull
+    docker compose up -d
+    ```
+
+=== "Ephemeral `moodlehtml`"
+
+    Pros: upgrading Moodle is just `docker compose pull && docker compose up -d`.
+
+    Cons: you must re-install plugins and re-apply theme customisations on every rebuild, or install them via `POST_CONFIGURE_COMMANDS` on every start.
+
+    ```yaml
+    services:
+      moodle:
+        volumes:
+          - moodledata:/var/www/moodledata
+          # no moodlehtml volume
+    ```
+
+    Pair this with idempotent Moosh commands:
+
+    ```yaml
+    environment:
+      POST_CONFIGURE_COMMANDS: |
+        moosh plugin-list
+        moosh plugin-install --delete mod_attendance
+    ```
+
+!!! info "Future improvement"
+    [#103](https://github.com/erseco/alpine-moodle/issues/103) tracks a finer-grained approach that would persist only `config.php`, themes and modules. Until that lands, pick the pattern that matches your risk tolerance.
+
+## PostgreSQL 18+ volume path
+
+Since PostgreSQL 18, the official `postgres` image expects the named volume at `/var/lib/postgresql`, not `/var/lib/postgresql/data` ([#133](https://github.com/erseco/alpine-moodle/issues/133)). If you pull `postgres:alpine` today you are on 18+.
+
+```yaml
+# Correct for postgres:18+ (and postgres:alpine today)
+volumes:
+  - postgres:/var/lib/postgresql
+```
+
+If you already have an existing volume created with the old path, follow the [`PGDATA` migration notes on Docker Hub](https://hub.docker.com/_/postgres) before switching. Mounting the old path on a new major version can silently overwrite your data.
+
+## Permissions
+
+The container runs as the non-privileged `nobody` user (UID `65534`). Named Docker volumes get the right ownership automatically. **Bind mounts do not** — if you mount a host directory, make sure it is writable by UID `65534`:
+
+```bash
+sudo chown -R 65534:65534 ./moodledata ./moodlehtml
+```
+
+See [#2](https://github.com/erseco/alpine-moodle/issues/2), [#6](https://github.com/erseco/alpine-moodle/issues/6), [#117](https://github.com/erseco/alpine-moodle/issues/117) for historical permission problems.
+
+## Backups
+
+Minimal backup plan for a PostgreSQL + named-volumes deployment:
+
+```bash
+# 1. Database
+docker compose exec -T postgres pg_dump -U moodle moodle | gzip > moodle-db.sql.gz
+
+# 2. Moodle data (uploads, sessions, file storage)
+docker run --rm \
+  -v <project>_moodledata:/data:ro \
+  -v "$PWD":/backup \
+  alpine tar czf /backup/moodledata.tar.gz -C /data .
+
+# 3. (Optional) Moodle code + plugins + config.php
+docker run --rm \
+  -v <project>_moodlehtml:/html:ro \
+  -v "$PWD":/backup \
+  alpine tar czf /backup/moodlehtml.tar.gz -C /html .
+```
+
+Restore is the reverse: recreate the volumes, extract the tarballs back into them, and run `pg_restore`.
+
+!!! tip
+    Put the site into maintenance mode before taking a cold backup:
+
+    ```bash
+    docker compose exec moodle php admin/cli/maintenance.php --enable
+    # ... run backup ...
+    docker compose exec moodle php admin/cli/maintenance.php --disable
+    ```

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,0 +1,87 @@
+# Quick Start
+
+This page shows the fastest way to get a working Moodle instance.
+
+!!! tip
+    Always override `MOODLE_USERNAME` and `MOODLE_PASSWORD`. The defaults (`moodleuser` / `PLEASE_CHANGEME`) must never be used in a reachable environment.
+
+## Option 1 — Single container (SQLite)
+
+Great for local demos, evaluation, and CI smoke tests. **Not for production.**
+
+```bash
+docker run -d --name moodle \
+  -p 80:8080 \
+  -e MOODLE_DATABASE_TYPE=sqlite3 \
+  -e MOODLE_USERNAME=admin \
+  -e MOODLE_PASSWORD=ChangeMe123! \
+  -e SITE_URL=http://localhost \
+  -v moodledata:/var/www/moodledata \
+  erseco/alpine-moodle
+```
+
+Then watch the logs until initialization finishes:
+
+```bash
+docker logs -f moodle
+```
+
+Open <http://localhost> and log in.
+
+## Option 2 — Docker Compose with PostgreSQL
+
+The recommended minimum for a persistent deployment:
+
+```yaml
+services:
+  postgres:
+    image: postgres:alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_PASSWORD: moodle
+      POSTGRES_USER: moodle
+      POSTGRES_DB: moodle
+    volumes:
+      - postgres:/var/lib/postgresql
+
+  moodle:
+    image: erseco/alpine-moodle
+    restart: unless-stopped
+    environment:
+      SITE_URL: http://localhost
+      DB_TYPE: pgsql
+      DB_HOST: postgres
+      DB_NAME: moodle
+      DB_USER: moodle
+      DB_PASS: moodle
+      MOODLE_USERNAME: admin
+      MOODLE_PASSWORD: ChangeMe123!
+    ports:
+      - "80:8080"
+    volumes:
+      - moodledata:/var/www/moodledata
+      - moodlehtml:/var/www/html
+    depends_on:
+      - postgres
+
+volumes:
+  postgres:
+  moodledata:
+  moodlehtml:
+```
+
+Start the stack:
+
+```bash
+docker compose up -d
+docker compose logs -f moodle
+```
+
+The first boot installs the database schema and runs the Moodle CLI installer. Subsequent boots reuse the existing data.
+
+## What to do next
+
+- Put the container [behind a reverse proxy](reverse-proxy.md) for HTTPS.
+- Review the [environment variables](environment-variables.md) to tune PHP limits, SMTP, Redis, etc.
+- Read [Persistence & Volumes](persistence.md) before your first backup.
+- When upgrading Moodle, follow [Upgrading](upgrading.md).

--- a/docs/reverse-proxy.md
+++ b/docs/reverse-proxy.md
@@ -1,0 +1,223 @@
+# Reverse Proxy
+
+Most deployments run `alpine-moodle` behind a reverse proxy that terminates TLS. This page documents how to wire that up correctly and how to avoid the recurring pitfalls reported in issues like [#15](https://github.com/erseco/alpine-moodle/issues/15), [#21](https://github.com/erseco/alpine-moodle/issues/21), [#51](https://github.com/erseco/alpine-moodle/issues/51), [#57](https://github.com/erseco/alpine-moodle/issues/57), [#61](https://github.com/erseco/alpine-moodle/issues/61), [#101](https://github.com/erseco/alpine-moodle/issues/101), [#127](https://github.com/erseco/alpine-moodle/issues/127) and [#137](https://github.com/erseco/alpine-moodle/issues/137).
+
+## How Moodle sees the world
+
+Moodle builds every URL from `$CFG->wwwroot`. That value is derived from `SITE_URL` at first start. If `wwwroot` does not exactly match the URL the browser uses, you will see:
+
+- **Broken CSS / JS** — assets are generated against a different origin, triggering mixed content or 404s.
+- **`ERR_TOO_MANY_REDIRECTS`** — Moodle keeps redirecting to its canonical `wwwroot` because the incoming request looks different.
+- **Login loops** — session cookies are set on a host Moodle does not recognise.
+
+To use a reverse proxy correctly you need to tell Moodle two things:
+
+1. The **public URL** users type in the browser → `SITE_URL`
+2. Whether the public connection is **HTTPS even though the container speaks HTTP** → `SSLPROXY=true`
+
+## The correct settings
+
+```yaml
+environment:
+  SITE_URL: https://moodle.example.com
+  SSLPROXY: "true"
+  REVERSEPROXY: "false"
+```
+
+| Variable       | Value                         | Purpose |
+|----------------|-------------------------------|---------|
+| `SITE_URL`     | Full **public** URL with scheme | Becomes `$CFG->wwwroot`. Must match what users type in the browser. |
+| `SSLPROXY`     | `true`                        | Trusts `X-Forwarded-Proto` so Moodle treats the request as HTTPS. |
+| `REVERSEPROXY` | `false` in most cases         | Only set to `true` if the same site is intentionally accessed under multiple base URLs (multi-tenant / multi-host). See [Moodle docs on reverse proxies](https://docs.moodle.org/en/Server_cluster). |
+
+!!! warning "`REVERSEPROXY=true` is rarely what you want"
+    Setting `REVERSEPROXY=true` on a single-URL deployment triggers *"Reverse proxy enabled so the server cannot be accessed directly"* errors (issue [#137](https://github.com/erseco/alpine-moodle/issues/137)). Leave it at `false` unless you actually serve the same site from several hostnames.
+
+## Required proxy headers
+
+Whatever proxy you use, it must forward these headers:
+
+- `Host` — the public hostname
+- `X-Forwarded-Proto` — `https`
+- `X-Forwarded-For` — the real client IP
+
+Without `X-Forwarded-Proto: https` the `SSLPROXY` flag has nothing to trust and Moodle will keep redirecting to HTTP.
+
+## Traefik (v2 / v3)
+
+Label-based configuration, no file changes required on the Traefik side.
+
+```yaml
+services:
+  moodle:
+    image: erseco/alpine-moodle
+    restart: unless-stopped
+    environment:
+      SITE_URL: https://moodle.example.com
+      SSLPROXY: "true"
+      DB_HOST: postgres
+      DB_USER: moodle
+      DB_PASS: moodle
+      DB_NAME: moodle
+      MOODLE_USERNAME: admin
+      MOODLE_PASSWORD: ChangeMe123!
+    volumes:
+      - moodledata:/var/www/moodledata
+      - moodlehtml:/var/www/html
+    networks:
+      - proxy
+      - default
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=proxy"
+      - "traefik.http.routers.moodle.rule=Host(`moodle.example.com`)"
+      - "traefik.http.routers.moodle.entrypoints=websecure"
+      - "traefik.http.routers.moodle.tls=true"
+      - "traefik.http.routers.moodle.tls.certresolver=letsencrypt"
+      - "traefik.http.services.moodle.loadbalancer.server.port=8080"
+
+networks:
+  proxy:
+    external: true
+```
+
+Traefik forwards `X-Forwarded-Proto` automatically when the entry point terminates TLS, so nothing else is needed.
+
+!!! tip "502 Bad Gateway with Traefik"
+    A 502 from Traefik (issue [#61](https://github.com/erseco/alpine-moodle/issues/61)) usually means the service port is wrong. The container listens on **8080**, not 80. Set `traefik.http.services.moodle.loadbalancer.server.port=8080`.
+
+## Nginx
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name moodle.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/moodle.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/moodle.example.com/privkey.pem;
+
+    client_max_body_size 100M;
+
+    location / {
+        proxy_pass         http://moodle:8080;
+        proxy_http_version 1.1;
+
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto https;
+        proxy_set_header   X-Forwarded-Host  $host;
+
+        proxy_read_timeout 300s;
+    }
+}
+
+server {
+    listen 80;
+    server_name moodle.example.com;
+    return 301 https://$host$request_uri;
+}
+```
+
+Set `client_max_body_size` high enough to allow large course uploads. Also raise the matching PHP variables (`post_max_size`, `upload_max_filesize`) on the Moodle container.
+
+## Nginx Proxy Manager
+
+NPM is popular for homelab deployments and is the source of several support questions ([#51](https://github.com/erseco/alpine-moodle/issues/51)).
+
+1. Expose the container on an internal Docker network that NPM can reach (no host port required).
+2. In NPM, create a **Proxy Host**:
+    - **Domain Names**: `moodle.example.com`
+    - **Scheme**: `http`
+    - **Forward Hostname / IP**: the container name (e.g. `moodle`)
+    - **Forward Port**: `8080`
+    - Toggle **Block Common Exploits**: off (NPM's WAF can break some Moodle paths)
+    - Toggle **Websockets Support**: on
+3. On the **SSL** tab, request a Let's Encrypt certificate and enable **Force SSL** and **HTTP/2**.
+4. Under **Advanced**, add:
+
+    ```nginx
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header X-Forwarded-Host  $host;
+    client_max_body_size 100M;
+    ```
+
+5. In your `docker-compose.yml` for Moodle, set `SITE_URL=https://moodle.example.com` and `SSLPROXY=true`.
+
+## Apache (mod_proxy)
+
+```apache
+<VirtualHost *:443>
+    ServerName moodle.example.com
+
+    SSLEngine on
+    SSLCertificateFile      /etc/letsencrypt/live/moodle.example.com/fullchain.pem
+    SSLCertificateKeyFile   /etc/letsencrypt/live/moodle.example.com/privkey.pem
+
+    ProxyPreserveHost On
+    ProxyRequests Off
+
+    RequestHeader set X-Forwarded-Proto "https"
+    RequestHeader set X-Forwarded-Port  "443"
+
+    ProxyPass        / http://moodle:8080/
+    ProxyPassReverse / http://moodle:8080/
+
+    <Proxy *>
+        Require all granted
+    </Proxy>
+</VirtualHost>
+
+<VirtualHost *:80>
+    ServerName moodle.example.com
+    Redirect permanent / https://moodle.example.com/
+</VirtualHost>
+```
+
+Enable the required modules once:
+
+```bash
+a2enmod proxy proxy_http ssl headers rewrite
+```
+
+## Caddy
+
+```caddy
+moodle.example.com {
+    reverse_proxy moodle:8080 {
+        header_up Host              {host}
+        header_up X-Forwarded-Proto {scheme}
+        header_up X-Forwarded-For   {remote}
+    }
+}
+```
+
+With `SITE_URL=https://moodle.example.com` and `SSLPROXY=true` on the Moodle container this is all you need — Caddy will obtain and renew TLS automatically.
+
+## Cloudflare / Cloudflared
+
+If you front Moodle with Cloudflare (proxied DNS or `cloudflared` tunnel), Cloudflare already injects `X-Forwarded-Proto: https`. You only need:
+
+```yaml
+environment:
+  SITE_URL: https://moodle.example.com
+  SSLPROXY: "true"
+  REVERSEPROXY: "false"
+```
+
+To log the real visitor IP instead of the Cloudflare edge IP, enable the `CF-Connecting-IP` header in your front proxy (or use Cloudflare's *True-Client-IP*) and ensure the next proxy hop copies it into `X-Forwarded-For`.
+
+## Reverse proxy with a URL prefix
+
+Moodle does **not** support being served from a subpath such as `https://example.com/mylms/` (issue [#127](https://github.com/erseco/alpine-moodle/issues/127)). Upstream Moodle requires its own hostname or subdomain. If you need path-based routing, use a dedicated subdomain (`moodle.example.com`) instead.
+
+## Checklist
+
+Before opening a support issue, verify:
+
+- [ ] `SITE_URL` is the **public** URL, starts with `https://`, no trailing slash.
+- [ ] `SSLPROXY=true` is set when the proxy terminates TLS.
+- [ ] `REVERSEPROXY=false` (unless you really use multiple base URLs).
+- [ ] The proxy forwards `Host`, `X-Forwarded-Proto` and `X-Forwarded-For`.
+- [ ] The upstream port is `8080`, not `80`.
+- [ ] You restarted the container after changing `SITE_URL` on an existing installation and, if necessary, manually updated `wwwroot` in `config.php`.

--- a/docs/sqlite.md
+++ b/docs/sqlite.md
@@ -1,0 +1,98 @@
+# SQLite Single-Container Mode
+
+`alpine-moodle` can run with an embedded SQLite database instead of PostgreSQL or MariaDB. The entire Moodle stack — web, PHP, database — fits in a single container with one mounted volume.
+
+!!! danger "Development, demos and CI only"
+    SQLite mode exists for fast local evaluation, ephemeral demos, and smoke tests in pipelines. **Do not run production workloads on SQLite.** Moodle's SQLite support is still experimental ([MDL-88218](https://moodle.atlassian.net/browse/MDL-88218)) and performance under concurrent load is not adequate for real use.
+
+## When to use it
+
+- You want to evaluate Moodle in under a minute.
+- You are writing a plugin and need a disposable instance.
+- Your CI pipeline boots Moodle to run automated tests against it.
+- You are recording a tutorial or demo and do not want a database service.
+
+For anything else, use [PostgreSQL or MariaDB](docker-compose.md).
+
+## One-command boot
+
+```bash
+docker run -d --name moodle \
+  -p 80:8080 \
+  -e MOODLE_DATABASE_TYPE=sqlite3 \
+  -e MOODLE_USERNAME=admin \
+  -e MOODLE_PASSWORD=ChangeMe123! \
+  -v moodledata:/var/www/moodledata \
+  erseco/alpine-moodle
+```
+
+Open <http://localhost>, log in with `admin` / `ChangeMe123!`, done.
+
+## Compose variant
+
+```yaml
+services:
+  moodle:
+    image: erseco/alpine-moodle
+    restart: unless-stopped
+    environment:
+      MOODLE_DATABASE_TYPE: sqlite3
+      MOODLE_USERNAME: admin
+      MOODLE_PASSWORD: ChangeMe123!
+      SITE_URL: http://localhost:8080
+    ports:
+      - "8080:8080"
+    volumes:
+      - moodledata:/var/www/moodledata
+
+volumes:
+  moodledata:
+```
+
+## How it works
+
+When `MOODLE_DATABASE_TYPE=sqlite3` (or `DB_TYPE=sqlite3`), the startup script:
+
+1. Skips the external database wait loop — no `nc` polling for `DB_HOST`.
+2. Creates `/var/www/moodledata/sqlite/` if it does not exist and touches an empty `moodle.sqlite` file.
+3. Writes a hand-crafted `config.php` that sets `dbtype=sqlite3`, `dblibrary=pdo` and points `dbname` at the SQLite file.
+4. Runs `admin/cli/install_database.php` to create the schema.
+5. Proceeds with the normal Moodle configuration (SMTP, Redis, cfg tweaks, cron).
+
+The SQLite driver patches ([MDL-88218](https://moodle.atlassian.net/browse/MDL-88218)) are applied at **image build time** for supported Moodle versions:
+
+| Moodle version | SQLite patch available? |
+|----------------|-------------------------|
+| `main` / `v5.2*` | Yes (from `ateeducacion/moodle` PR #1) |
+| `v5.1*`          | Yes (PR #2) |
+| `v5.0*`          | Yes (PR #3) |
+| `v4.x` and older | **No** — the image will warn at build time and SQLite mode will not work |
+
+## Customising the SQLite file location
+
+The default is `/var/www/moodledata/sqlite/moodle.sqlite`. You can override it, but the resolved path must stay inside `/var/www/moodledata/` — the container refuses to run otherwise.
+
+```yaml
+environment:
+  MOODLE_DATABASE_TYPE: sqlite3
+  DB_SQLITE_PATH: /var/www/moodledata/custom/moodle.sqlite
+```
+
+The containing directory is created with mode `0700` and the database file with mode `0600`, both owned by the `nobody` user.
+
+## Limitations
+
+- **Concurrent writes**: SQLite is single-writer. Under simultaneous form submissions or imports you will see locking errors.
+- **No replicas**: `DB_HOST_REPLICA` and related replica variables are ignored.
+- **No external database tools**: you cannot connect `psql` or `mysql` to a SQLite file. Use the SQLite CLI or DB Browser for SQLite.
+- **Upgrades**: the experimental driver is still moving upstream. Pinning an exact Moodle tag is strongly recommended when you use SQLite.
+
+## Going from SQLite to PostgreSQL later
+
+SQLite mode is one-way. To migrate a demo into a proper database you need to:
+
+1. Dump courses and users with Moodle's course backup tools or `moosh course-backup`.
+2. Recreate the stack with PostgreSQL or MariaDB.
+3. Restore the course backups into the new instance.
+
+There is no automatic schema conversion.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,199 @@
+# Troubleshooting
+
+The most common problems users run into, mined from GitHub Issues. Each entry links to the original report so you can dig deeper.
+
+## CSS is missing / site looks broken
+
+**Symptoms**: Moodle renders with plain HTML, no styling, images fail to load. Browser console shows mixed-content blocks or 404s on `/theme/yui_combo.php` etc.
+
+**Cause**: `$CFG->wwwroot` does not match the URL the browser uses. This is almost always a reverse-proxy / `SITE_URL` mismatch. Related: [#21](https://github.com/erseco/alpine-moodle/issues/21), [#101](https://github.com/erseco/alpine-moodle/issues/101).
+
+**Fix**:
+
+```yaml
+environment:
+  SITE_URL: https://moodle.example.com   # the PUBLIC URL
+  SSLPROXY: "true"                       # proxy terminates TLS
+  REVERSEPROXY: "false"
+```
+
+Then restart the container and purge caches:
+
+```bash
+docker compose restart moodle
+docker compose exec moodle php admin/cli/purge_caches.php
+```
+
+## `ERR_TOO_MANY_REDIRECTS`
+
+**Cause**: Moodle thinks the connection is HTTP while the browser uses HTTPS, so it keeps redirecting to its canonical `wwwroot`. Related: [#15](https://github.com/erseco/alpine-moodle/issues/15).
+
+**Fix**:
+
+- Set `SSLPROXY=true`.
+- Make sure your proxy forwards `X-Forwarded-Proto: https`.
+- Set `SITE_URL` to the HTTPS URL.
+
+## "Reverse proxy enabled so the server cannot be accessed directly"
+
+**Cause**: `REVERSEPROXY=true` on a single-URL deployment. Moodle refuses direct access when it expects multiple base URLs. Related: [#137](https://github.com/erseco/alpine-moodle/issues/137).
+
+**Fix**: set `REVERSEPROXY=false`. Keep `SSLPROXY=true`.
+
+## 502 Bad Gateway behind Traefik
+
+**Cause**: Traefik is pointing at the wrong port. The container listens on **8080**, not 80. Related: [#61](https://github.com/erseco/alpine-moodle/issues/61).
+
+**Fix**:
+
+```yaml
+labels:
+  - "traefik.http.services.moodle.loadbalancer.server.port=8080"
+```
+
+## "Real client IPs" are all the Docker gateway
+
+**Cause**: The proxy is not forwarding `X-Forwarded-For`, or a middle hop is stripping it. Related: [#11](https://github.com/erseco/alpine-moodle/issues/11), [#137](https://github.com/erseco/alpine-moodle/issues/137).
+
+**Fix**: Make the outermost proxy set `X-Forwarded-For` to the real client IP. Each downstream hop must append (not replace) it. Confirm by running `docker compose exec moodle tail -f /var/log/nginx/access.log` and watching the IP in the request line.
+
+Cloudflare users can use `CF-Connecting-IP` instead.
+
+## `Allowed memory size exhausted` when installing a plugin with Moosh
+
+**Cause**: Default `memory_limit` (256M) is too low for some plugins. Related: [#119](https://github.com/erseco/alpine-moodle/issues/119).
+
+**Fix**:
+
+```yaml
+environment:
+  memory_limit: 512M
+```
+
+Restart the container. Then re-run the Moosh command — don't forget the `--delete` flag to work around the known Moosh install bug:
+
+```bash
+docker compose exec moodle moosh plugin-install --delete theme_almondb
+```
+
+## `pluglist.php ... HTTP/1.1 403 Forbidden`
+
+**Cause**: Transient issue with `download.moodle.org` hitting Moosh's plugin list endpoint. Related: [#95](https://github.com/erseco/alpine-moodle/issues/95).
+
+**Fix**:
+
+```bash
+docker compose exec moodle rm -f /tmp/.moosh/plugins.json
+docker compose exec moodle moosh plugin-list
+```
+
+Retry after a few minutes if it keeps 403'ing.
+
+## PostgreSQL connection refused on a custom port
+
+**Cause**: `DB_PORT` is not being passed through. Make sure it is a string (quoted) in YAML. Related: [#78](https://github.com/erseco/alpine-moodle/issues/78).
+
+**Fix**:
+
+```yaml
+environment:
+  DB_TYPE: pgsql
+  DB_HOST: postgres.example.com
+  DB_PORT: "5060"
+  DB_NAME: moodle
+  DB_USER: moodle
+  DB_PASS: moodle
+```
+
+## Data loss after `docker compose down && up` with PostgreSQL 18+
+
+**Cause**: Recent `postgres:alpine` images (18+) expect the named volume at `/var/lib/postgresql`, not `/var/lib/postgresql/data`. Mounting the wrong path makes Postgres create an *anonymous* volume and Moodle starts from scratch. Related: [#133](https://github.com/erseco/alpine-moodle/issues/133).
+
+**Fix**:
+
+```yaml
+volumes:
+  - postgres:/var/lib/postgresql
+```
+
+Follow the [`PGDATA` migration notes](https://hub.docker.com/_/postgres) if you already have an old volume.
+
+## "Data directory (/var/www/moodledata/) cannot be created by the installer"
+
+**Cause**: The mounted `moodledata` is not writable by UID `65534` (`nobody`), or you are reusing a populated `moodledata` from another image with mismatched permissions. Related: [#114](https://github.com/erseco/alpine-moodle/issues/114), [#2](https://github.com/erseco/alpine-moodle/issues/2).
+
+**Fix**:
+
+```bash
+sudo chown -R 65534:65534 ./moodledata
+```
+
+For bind mounts only. Named Docker volumes get the right ownership automatically.
+
+## Plugins disappear after upgrading
+
+**Cause**: The `moodlehtml` volume was removed during the upgrade. Plugins live inside `/var/www/html/...`. Related: [#9](https://github.com/erseco/alpine-moodle/issues/9), [#103](https://github.com/erseco/alpine-moodle/issues/103).
+
+**Fix**: Reinstall via `POST_CONFIGURE_COMMANDS` so they are reapplied automatically:
+
+```yaml
+environment:
+  POST_CONFIGURE_COMMANDS: |
+    moosh plugin-list
+    moosh plugin-install --delete mod_attendance
+```
+
+## Upgrade seems to do nothing — "No upgrade needed"
+
+**Cause**: Old Moodle code is still in the `moodlehtml` volume because you changed the image tag without clearing it. Related: [#102](https://github.com/erseco/alpine-moodle/issues/102).
+
+**Fix**: Back up, then remove the `moodlehtml` volume and restart:
+
+```bash
+docker compose down
+docker volume rm <project>_moodlehtml
+docker compose pull
+docker compose up -d
+```
+
+See [Upgrading](upgrading.md) for the full procedure.
+
+## LDAP says the PHP module is missing
+
+**Cause**: Old image tag. `php-ldap` is bundled in current releases. Related: [#122](https://github.com/erseco/alpine-moodle/issues/122).
+
+**Fix**: `docker compose pull` to update to a current tag. If you use a custom LDAP CA, pass it via `MY_CERTIFICATES` (base64-encoded PEM).
+
+## `/var/www/html/vendor/composer does not exist`
+
+**Cause**: Moodle 5.1+ requires `composer install` to run inside the container on first start. If you stopped the container during this step or mounted an incomplete `/var/www/html`, the vendor directory is missing. Related: [#117](https://github.com/erseco/alpine-moodle/issues/117).
+
+**Fix**: Let the container start fully and watch the logs. If it persists, enter the container and run:
+
+```bash
+docker compose exec moodle composer install --no-dev --classmap-authoritative \
+  --working-dir=/var/www/html
+```
+
+## Cron-related errors ("exit status 127")
+
+**Cause**: Historically `php` was missing from the cron service environment. Related: [#18](https://github.com/erseco/alpine-moodle/issues/18).
+
+**Fix**: Update to a current image. If you want to disable the internal cron entirely, set `RUN_CRON_TASKS=false` and schedule `admin/cli/cron.php` externally.
+
+## `config.php writable` warning
+
+**Cause**: `config.php` is intentionally made read-only after install for security. Moodle surfaces this as a warning in the admin dashboard. Related: [#12](https://github.com/erseco/alpine-moodle/issues/12).
+
+**Fix**: This is by design and can be safely ignored. It is not an error.
+
+## Where to find Moodle debug output
+
+Enable developer debug mode in the container:
+
+```yaml
+environment:
+  DEBUG: "true"
+```
+
+Then read logs with `docker compose logs -f moodle` and browse the site — errors appear both in the logs and rendered in the page. Related: [#25](https://github.com/erseco/alpine-moodle/issues/25).

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,0 +1,129 @@
+# Upgrading
+
+How to move between Moodle versions safely.
+
+## The basics
+
+The image applies Moodle database upgrades automatically on startup unless you opt out:
+
+```yaml
+environment:
+  AUTO_UPDATE_MOODLE: "true"   # default — runs admin/cli/upgrade.php at boot
+```
+
+Steps the container takes on start, when an existing installation is detected:
+
+1. `admin/cli/maintenance.php --enable`
+2. `admin/cli/upgrade.php --non-interactive --allow-unstable`
+3. `admin/cli/maintenance.php --disable`
+
+This covers **database schema** upgrades. It does **not** by itself swap out the Moodle PHP code — that depends on how you handle the `/var/www/html` volume.
+
+## Upgrading the Moodle code
+
+Your upgrade procedure depends on whether you persist `/var/www/html` as a named volume.
+
+=== "Without `moodlehtml` volume"
+
+    The container replaces the Moodle code on every start. Upgrading is just:
+
+    ```bash
+    docker compose pull
+    docker compose up -d
+    ```
+
+    Trade-off: plugins and themes must be re-installed on every boot (use `POST_CONFIGURE_COMMANDS` with Moosh).
+
+=== "With `moodlehtml` volume"
+
+    Pinned Moodle code in a persistent volume will **not** be overwritten when you change the image tag ([#102](https://github.com/erseco/alpine-moodle/issues/102)). You will see logs like:
+
+    ```
+    No upgrade needed for the installed version 5.0.1 (Build: 20250609). Thanks for coming anyway!
+    ```
+
+    To actually upgrade:
+
+    1. Back up the database, `moodledata`, and `moodlehtml` (see [Persistence & Volumes](persistence.md)).
+    2. Put the site into maintenance mode (optional but recommended).
+    3. Stop the stack and remove the `moodlehtml` volume:
+
+        ```bash
+        docker compose down
+        docker volume rm <project>_moodlehtml
+        ```
+
+    4. Change the image tag in `docker-compose.yml`:
+
+        ```yaml
+        services:
+          moodle:
+            image: erseco/alpine-moodle:v5.0.2
+        ```
+
+    5. Bring it back up:
+
+        ```bash
+        docker compose pull
+        docker compose up -d
+        docker compose logs -f moodle
+        ```
+
+    6. Reinstall any custom plugins and themes.
+
+!!! warning "Always back up first"
+    Upgrades that involve removing volumes are irreversible. Take a database dump and a tarball of `moodledata` before you run `docker volume rm`.
+
+## Upgrading from Moodle < 5.1 to ≥ 5.1
+
+Moodle 5.1 introduces a `public/` subdirectory for all web-exposed files ([MDL-83424](https://moodle.atlassian.net/browse/MDL-83424)). The container handles this automatically: when it detects `/var/www/html/public`, it rewrites the Nginx root and runs `composer install --no-dev --classmap-authoritative`.
+
+Recommended upgrade flow:
+
+1. Back up:
+    - `config.php`
+    - the `moodledata` volume
+    - the database
+2. Stop the stack and remove the `moodlehtml` volume (as above) — this is essential because the old 5.0 layout will otherwise confuse the new server config.
+3. Change the image tag to a `5.1.x` (or newer) release.
+4. Start the stack. The container installs the new code, serves it from `/public`, and runs `composer install`.
+5. Reapply customisations (plugins, themes, `config.php` tweaks).
+
+If you see *"`/var/www/html/vendor/composer` does not exist"* ([#117](https://github.com/erseco/alpine-moodle/issues/117)), the container has not finished bootstrapping yet. Watch `docker compose logs -f moodle` — the error is transient unless it recurs after 30+ seconds.
+
+## Upgrading `moodledata` mounted from an older installation
+
+Mounting an existing populated `moodledata` from a different image (for example migrating from Bitnami) can hit permission or layout mismatches ([#114](https://github.com/erseco/alpine-moodle/issues/114), [#105](https://github.com/erseco/alpine-moodle/issues/105)):
+
+```
+Data directory (/var/www/moodledata/) cannot be created by the installer.
+```
+
+Checklist:
+
+- The volume must be writable by UID `65534` (`nobody`). Fix with `sudo chown -R 65534:65534 moodledata`.
+- `config.php` on the new container must match the database — mount it alongside or inject it via `POST_CONFIGURE_COMMANDS`.
+- The target Moodle version must be equal to or newer than the version that created the data.
+
+For a full Bitnami migration see [#105](https://github.com/erseco/alpine-moodle/issues/105). In short: restore the database first, mount `moodledata` second, ensure the admin credentials in `config.php` match the database, then start the container.
+
+## Disabling automatic upgrades
+
+Set `AUTO_UPDATE_MOODLE=false` if you prefer to run `admin/cli/upgrade.php` manually:
+
+```yaml
+environment:
+  AUTO_UPDATE_MOODLE: "false"
+```
+
+Manual upgrade:
+
+```bash
+docker compose exec moodle php admin/cli/maintenance.php --enable
+docker compose exec moodle php admin/cli/upgrade.php --non-interactive
+docker compose exec moodle php admin/cli/maintenance.php --disable
+```
+
+## Skipping versions
+
+Moodle's upgrade scripts support skipping minor versions but you should not jump across multiple major versions in one go. Upgrade step by step (for example `4.1 → 4.5 → 5.0 → 5.1`), backing up between each step.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,93 @@
+site_name: Alpine Moodle
+site_description: Lightweight Moodle Docker image built on Alpine Linux — official documentation.
+site_url: https://erseco.github.io/alpine-moodle/
+repo_url: https://github.com/erseco/alpine-moodle
+repo_name: erseco/alpine-moodle
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  language: en
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - navigation.instant
+    - navigation.tracking
+    - navigation.indexes
+    - toc.follow
+    - search.suggest
+    - search.highlight
+    - search.share
+    - content.code.copy
+    - content.code.annotate
+    - content.tabs.link
+    - content.action.edit
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: deep orange
+      accent: deep orange
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: deep orange
+      accent: deep orange
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  icon:
+    repo: fontawesome/brands/github
+    logo: material/school
+
+nav:
+  - Home: index.md
+  - Quick Start: quick-start.md
+  - Docker Compose: docker-compose.md
+  - Reverse Proxy: reverse-proxy.md
+  - Environment Variables: environment-variables.md
+  - Persistence & Volumes: persistence.md
+  - Configuration: configuration.md
+  - SQLite Mode: sqlite.md
+  - Upgrading: upgrading.md
+  - Troubleshooting: troubleshooting.md
+  - FAQ: faq.md
+
+markdown_extensions:
+  - abbr
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.keys
+  - pymdownx.mark
+  - pymdownx.caret
+  - pymdownx.tilde
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/erseco/alpine-moodle
+    - icon: fontawesome/brands/docker
+      link: https://hub.docker.com/r/erseco/alpine-moodle


### PR DESCRIPTION
Closes #139

## Summary

Publishes a full documentation site under `docs/` built with [Zensical](https://zensical.org/), and deploys it to GitHub Pages on every push to `main`.

The `README.md` is slimmed down to a short overview + quick start + a prominent link to the docs site. All of the long-form content that used to live in the README (reverse-proxy troubleshooting, env-var table, SQLite notes, upgrade gotchas) has been moved into properly-navigable pages.

## What's new

**New docs tree (`docs/`)**

- `index.md` — landing page with feature overview + navigation cards
- `quick-start.md` — SQLite and Postgres one-liners
- `docker-compose.md` — minimal, Redis, proxied, MariaDB and SQLite stacks
- `reverse-proxy.md` — Traefik, Nginx, Nginx Proxy Manager, Apache, Caddy, Cloudflare
- `environment-variables.md` — full reference table grouped by concern
- `persistence.md` — `/var/www/html`, `/var/www/moodledata`, DB volume, PG 18+ path, UID 65534 permissions, backups
- `configuration.md` — pre/post hooks, Moosh, Moodle CLI, Redis, LDAP certs, cron
- `sqlite.md` — development/demo mode, caveats, patch support matrix
- `upgrading.md` — `AUTO_UPDATE_MOODLE`, `moodlehtml` trade-off, 5.0 → 5.1 `/public` path, Bitnami migration notes
- `troubleshooting.md` — issue-mined failure modes with fixes
- `faq.md` — short answers to recurring questions

**Tooling**

- `mkdocs.yml` — Material theme, dark/light palette toggle, instant navigation, search suggestions/highlight, code copy button, annotations, linked content tabs, `pymdownx` extensions (admonitions, details, tabbed, tasklist, highlight, emoji).
- `.github/workflows/docs.yml` — builds with `pip install zensical && zensical build --clean`, uploads a Pages artifact, and deploys via `actions/deploy-pages@v4`. Runs only for `docs/**`, `mkdocs.yml` and the workflow itself. Uses the right `pages: write` + `id-token: write` permissions and a Pages concurrency group.

**README**

Refactored to: badges, one-paragraph description, prominent link to the docs site, single-container SQLite quick start, PostgreSQL compose quick start, key features list, registry pointers, table of contents into the published docs, contributing section.

## Issues mined

The docs explicitly address support patterns from the tracker:

- Reverse proxy / SSL / CSS / redirects: #15, #21, #51, #57, #61, #101, #127, #137
- Real client IPs / forwarded headers: #11, #137
- Upgrades and `moodlehtml` volume: #102, #103, #114, #105, #13
- Persistence / permissions: #2, #6, #9, #76, #117, #133
- Memory limits for Moosh: #119
- LDAP module / certificates: #122
- Cron: #98, #18
- First-install errors: #7, #22, #117
- Moodle 5.1 `/public`: #97
- Custom Postgres port: #78
- Moosh pluglist 403: #95
- \`config.php writable\` warning: #12
- Debug output: #25

## Assumptions made

- Pages will be published from GitHub Actions (not from a branch). Maintainer needs to set **Settings → Pages → Source: GitHub Actions** once.
- The site URL used in `mkdocs.yml` is `https://erseco.github.io/alpine-moodle/`.
- Zensical is MkDocs-Material compatible at the configuration level. The workflow uses the exact snippet from Zensical's own deployment docs.

## Test plan

- [ ] Merge and confirm the `docs` workflow runs on `main`
- [ ] Verify Pages deploy succeeds and <https://erseco.github.io/alpine-moodle/> loads
- [ ] Check dark/light toggle, search, and code copy button work
- [ ] Spot-check that every nav link resolves (all 11 pages exist in this PR)
- [ ] Confirm the README renders correctly on GitHub with the new docs link