### PR TITLE
Add experimental Moodle Playground blueprint support

### DIFF
--- a/.github/workflows/blueprint-tests.yml
+++ b/.github/workflows/blueprint-tests.yml
@@ -1,0 +1,40 @@
+name: blueprint-tests
+
+# Lint the Moodle blueprint runner, syntax-check its entrypoint hook and run the
+# dependency-free PHP unit tests. Kept separate from the heavy image build so it
+# stays fast on every pull request.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'rootfs/usr/local/bin/moodle-blueprint'
+      - 'rootfs/usr/local/lib/moodle-blueprint/**'
+      - 'rootfs/docker-entrypoint-init.d/03-apply-blueprint.sh'
+      - 'tests/blueprint/**'
+      - '.github/workflows/blueprint-tests.yml'
+  pull_request:
+    paths:
+      - 'rootfs/usr/local/bin/moodle-blueprint'
+      - 'rootfs/usr/local/lib/moodle-blueprint/**'
+      - 'rootfs/docker-entrypoint-init.d/03-apply-blueprint.sh'
+      - 'tests/blueprint/**'
+      - '.github/workflows/blueprint-tests.yml'
+  workflow_dispatch:
+
+jobs:
+  blueprint-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up PHP 8.3
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: zip
+          coverage: none
+
+      - name: Run blueprint checks
+        run: ./tests/blueprint/run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ LABEL maintainer="Ernesto Serrano <info@ernesto.es>"
 USER root
 RUN apk add --no-cache composer patch php83-posix php83-xmlwriter php83-pecl-redis \
     php83-ldap php83-pecl-igbinary php83-exif php83-sqlite3 php83-pdo_sqlite \
+    # php83-zip provides ZipArchive, used by the Moodle blueprint runner for
+    # safe bundle/plugin extraction.
+    php83-zip \
     # Remove alpine cache
     && rm -rf /var/cache/apk/*
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,104 @@ Define the ENV variables in `docker-compose.yml`. The full reference with notes,
 | `POST_CONFIGURE_COMMANDS`   |                      | Shell commands run after Moodle configuration (great for Moosh). |
 | `RUN_CRON_TASKS`            | `true`               | Set to `false` to disable the internal `runit`-managed cron loop. |
 
+## Moodle Playground Blueprints
+
+> ⚠️ **Experimental.** `alpine-moodle` can apply [Moodle Playground](https://github.com/ateeducacion/moodle-playground)-compatible `blueprint.json` files **after Moodle has been installed or upgraded**. This is an additional declarative provisioning layer for repeatable development, QA, CI and demo scenarios — it does not replace the environment-variable configuration. Only a documented subset of steps is implemented; unsupported steps fail clearly and unsafe steps are disabled by default.
+
+The same `blueprint.json` can describe one Moodle scenario for two complementary **sibling** runtimes:
+
+- **[`moodle-playground`](https://github.com/ateeducacion/moodle-playground)** — the browser/WASM runtime for ephemeral QA, demos, shareable reproductions and fast validation. No server required.
+- **`alpine-moodle`** — this Docker runtime for local development, CI, plugin development, integration testing, persistence and real server-side behaviour (cron, mail, database, file system).
+
+Author a blueprint once; run it in the browser for a quick look and in Docker when you need a real, persistent Moodle.
+
+A new startup hook (`rootfs/docker-entrypoint-init.d/03-apply-blueprint.sh`) runs after `02-configure-moodle.sh` and calls `/usr/local/bin/moodle-blueprint apply` when a blueprint variable is set.
+
+| Variable                                  | Description                                        | Default |
+| ----------------------------------------- | -------------------------------------------------- | ------- |
+| `MOODLE_BLUEPRINT`                        | Path to a blueprint JSON file inside the container | empty   |
+| `MOODLE_BLUEPRINT_URL`                    | Remote URL to a blueprint JSON file                | empty   |
+| `MOODLE_BLUEPRINT_BUNDLE`                 | Path to a local bundle directory or ZIP            | empty   |
+| `MOODLE_BLUEPRINT_FORCE`                  | Reapply even if already applied                    | `false` |
+| `MOODLE_BLUEPRINT_ON_ERROR`               | `abort` or `warn`                                  | `abort` |
+| `MOODLE_BLUEPRINT_ALLOW_REMOTE_RESOURCES` | Allow URL resources                                | `true`  |
+| `MOODLE_BLUEPRINT_ALLOW_UNSAFE_STEPS`     | Allow unsafe steps if implemented                  | `false` |
+| `MOODLE_BLUEPRINT_MAX_RESOURCE_SIZE`      | Max remote resource size                           | `50M`   |
+
+If several sources are set, precedence is `MOODLE_BLUEPRINT_BUNDLE` > `MOODLE_BLUEPRINT` > `MOODLE_BLUEPRINT_URL`.
+
+Compatibility matrix:
+
+| Step                  | Status      | Notes                            |
+| --------------------- | ----------- | -------------------------------- |
+| `setConfig`           | supported   | Uses Moodle CLI                  |
+| `setConfigs`          | supported   | Loops over `setConfig`           |
+| `setAdminAccount`     | supported   | Password not logged              |
+| `installMoodlePlugin` | supported   | ZIP resources, safe extraction   |
+| `installTheme`        | supported   | ZIP resources                    |
+| `setTheme`            | supported   | Sets Moodle theme config         |
+| `createCategory`      | supported   | Idempotent                       |
+| `createCourse`        | supported   | Idempotent by shortname          |
+| `createUser`          | supported   | Idempotent by username           |
+| `createUsers`         | supported   | Loops over `createUser`          |
+| `enrolUser`           | supported   | Manual enrolment                 |
+| `installMoodle`       | no-op       | Handled by container startup     |
+| `login`               | no-op       | Browser-only, not applicable     |
+| `restoreCourse`       | planned     | Fails clearly until implemented  |
+| `runPhpCode`          | disabled    | Unsafe                           |
+| `runPhpScript`        | disabled    | Unsafe                           |
+| `writeFile`           | disabled    | Unsafe by default                |
+| `unzip`               | disabled    | Unsafe by default                |
+
+Minimal example:
+
+```yaml
+services:
+  moodle:
+    image: erseco/alpine-moodle:latest
+    ports:
+      - "8080:8080"
+    environment:
+      MOODLE_DATABASE_TYPE: sqlite3
+      MOODLE_USERNAME: admin
+      MOODLE_PASSWORD: ChangeMe123!
+      MOODLE_EMAIL: admin@example.com
+      MOODLE_SITENAME: "Blueprint Demo"
+      MOODLE_BLUEPRINT: /blueprints/demo.blueprint.json
+    volumes:
+      - moodledata:/var/www/moodledata
+      - ./demo.blueprint.json:/blueprints/demo.blueprint.json:ro
+
+volumes:
+  moodledata:
+```
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/ateeducacion/moodle-playground/main/assets/blueprints/blueprint-schema.json",
+  "preferredVersions": { "php": "8.3", "moodle": "5.0" },
+  "landingPage": "/course/index.php",
+  "steps": [
+    { "step": "setConfig", "name": "debug", "value": 32767 },
+    { "step": "createCategory", "name": "Blueprint demo", "idnumber": "blueprint-demo" },
+    { "step": "createCourse", "fullname": "Blueprint demo course", "shortname": "BLUEPRINT101", "category": "blueprint-demo" },
+    { "step": "createUser", "username": "student1", "password": "ChangeMe123!", "email": "student1@example.com", "firstname": "Student", "lastname": "One" },
+    { "step": "enrolUser", "username": "student1", "course": "BLUEPRINT101", "role": "student" }
+  ]
+}
+```
+
+Bundles co-locate a `blueprint.json` with its resources (directory or ZIP, `blueprint.json` at the root or one directory deep, `__MACOSX` ignored):
+
+```text
+my-moodle-blueprint/
+├── blueprint.json
+└── plugins/
+    └── mod_example.zip
+```
+
+See the full guide, resource descriptors, security model and idempotency notes in **[docs/blueprints.md](docs/blueprints.md)** (published at <https://erseco.github.io/alpine-moodle/blueprints/>). A copy-pasteable example lives in [`docs/examples/demo.blueprint.json`](docs/examples/demo.blueprint.json).
+
 ## Key features
 
 - Compact image (~100 MB) built on [`erseco/alpine-php-webserver`](https://github.com/erseco/alpine-php-webserver)

--- a/docs/blueprints.md
+++ b/docs/blueprints.md
@@ -1,0 +1,356 @@
+# Moodle Playground Blueprints
+
+!!! warning "Experimental"
+    Blueprint support is **experimental** and currently implements a documented
+    subset of steps. Unsupported steps fail clearly and unsafe steps are
+    disabled by default. The blueprint runner never replaces the existing
+    environment-variable configuration — it is an additional, declarative
+    provisioning layer for repeatable development, QA, CI and demo scenarios.
+
+`alpine-moodle` can apply [Moodle Playground](https://github.com/ateeducacion/moodle-playground)-compatible
+`blueprint.json` files **after Moodle has been installed or upgraded**. A single
+declarative blueprint can therefore describe one Moodle scenario and run in two
+complementary, sibling runtimes:
+
+- **[Moodle Playground](https://github.com/ateeducacion/moodle-playground)** — the
+  browser/WASM runtime for **ephemeral QA, demos, shareable reproductions and
+  fast validation**. No server required; perfect for sharing a link with a
+  reviewer.
+- **alpine-moodle** — this Docker runtime for **local development, CI, plugin
+  development, integration testing, persistence and real server-side behaviour**
+  (cron, mail, database, file system).
+
+The two projects are **siblings**, not competitors: author a blueprint once, run
+it in the browser for a quick look, and run the same file in Docker when you need
+a real, persistent Moodle.
+
+## How it works
+
+A new startup hook, `rootfs/docker-entrypoint-init.d/03-apply-blueprint.sh`,
+runs **after** `02-configure-moodle.sh` (i.e. after Moodle is installed or
+upgraded). When any blueprint variable is set it calls the runner:
+
+```text
+/usr/local/bin/moodle-blueprint apply
+```
+
+The runner follows the same four phases as WordPress Playground: **declaration →
+resource resolution → validation → step execution**, executing steps
+sequentially and failing fast on the first error.
+
+## Environment variables
+
+| Variable                                  | Description                                        | Default |
+| ----------------------------------------- | -------------------------------------------------- | ------- |
+| `MOODLE_BLUEPRINT`                        | Path to a blueprint JSON file inside the container | empty   |
+| `MOODLE_BLUEPRINT_URL`                    | Remote URL to a blueprint JSON file                | empty   |
+| `MOODLE_BLUEPRINT_BUNDLE`                 | Path to a local bundle directory or ZIP            | empty   |
+| `MOODLE_BLUEPRINT_FORCE`                  | Reapply even if already applied                    | `false` |
+| `MOODLE_BLUEPRINT_ON_ERROR`               | `abort` or `warn`                                  | `abort` |
+| `MOODLE_BLUEPRINT_ALLOW_REMOTE_RESOURCES` | Allow URL resources                                | `true`  |
+| `MOODLE_BLUEPRINT_ALLOW_UNSAFE_STEPS`     | Allow unsafe steps if implemented                  | `false` |
+| `MOODLE_BLUEPRINT_MAX_RESOURCE_SIZE`      | Max remote resource size                           | `50M`   |
+
+- `MOODLE_BLUEPRINT_ON_ERROR=abort` fails container startup if blueprint
+  application fails; `warn` prints a warning and continues startup.
+- Secrets (passwords, tokens) are **never** written to the logs.
+
+## Blueprint sources
+
+Set one of the following. If several are set, this **precedence** applies:
+
+1. `MOODLE_BLUEPRINT_BUNDLE`
+2. `MOODLE_BLUEPRINT`
+3. `MOODLE_BLUEPRINT_URL`
+
+```sh
+# 1. Local blueprint file
+MOODLE_BLUEPRINT=/blueprints/demo.blueprint.json
+
+# 2. Remote blueprint file (http/https only)
+MOODLE_BLUEPRINT_URL=https://example.com/demo.blueprint.json
+
+# 3. Local bundle directory
+MOODLE_BLUEPRINT_BUNDLE=/blueprints/demo-bundle/
+
+# 4. Local bundle ZIP
+MOODLE_BLUEPRINT_BUNDLE=/blueprints/demo-bundle.zip
+```
+
+The selected source is printed in the logs.
+
+## Blueprint format
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/ateeducacion/moodle-playground/main/assets/blueprints/blueprint-schema.json",
+  "preferredVersions": {
+    "php": "8.3",
+    "moodle": "5.0"
+  },
+  "landingPage": "/course/view.php?id=2",
+  "constants": {
+    "ADMIN_USER": "admin"
+  },
+  "resources": {
+    "pluginZip": {
+      "url": "https://example.com/plugin.zip"
+    }
+  },
+  "steps": [
+    {
+      "step": "setConfig",
+      "name": "debug",
+      "value": 32767
+    }
+  ]
+}
+```
+
+The parser:
+
+- loads JSON and fails clearly on syntax errors;
+- requires `steps` to be an array, each entry carrying a non-empty `step` name;
+- substitutes `{{KEY}}` placeholders from `constants` throughout the blueprint;
+- resolves resource references like `@pluginZip`;
+- **preserves unknown top-level fields** (e.g. `runtime`) without failing;
+- fails clearly on unknown or unsupported step types, reporting the failing
+  step index and name.
+
+!!! note "`preferredVersions` and `landingPage` are advisory"
+    The Docker image selects its Moodle/PHP version at build time, so
+    `preferredVersions` is treated as a hint. `landingPage` is logged as a hint;
+    the Docker runtime does not auto-navigate a browser.
+
+## Resources
+
+Declare named resources at the top level and reference them from steps with
+`@name`, or inline a descriptor directly in a step. Supported descriptors:
+
+```json
+{ "url": "https://example.com/file.zip" }
+{ "resource": "url", "url": "https://example.com/file.zip" }
+{ "base64": "..." }
+{ "data-url": "data:text/plain;base64,..." }
+{ "literal": "text or JSON-compatible value" }
+{ "bundled": "plugins/my-plugin.zip" }
+{ "resource": "bundled", "path": "/plugins/my-plugin.zip" }
+```
+
+`bundled` paths are resolved relative to the extracted bundle directory. The
+browser-only `vfs` resource type is rejected with a clear message. Resolved
+resources are cached for the duration of a single run.
+
+## Supported steps
+
+| Step                  | Status      | Notes                                        |
+| --------------------- | ----------- | -------------------------------------------- |
+| `setConfig`           | supported   | Uses Moodle CLI (`admin/cli/cfg.php`)        |
+| `setConfigs`          | supported   | Loops over `setConfig` (`values`/`configs`)  |
+| `setAdminAccount`     | supported   | Password not logged                          |
+| `installMoodlePlugin` | supported   | ZIP resources, safe extraction               |
+| `installTheme`        | supported   | ZIP resources, enforces `theme_*`            |
+| `setTheme`            | supported   | Sets Moodle theme config                     |
+| `createCategory`      | supported   | Idempotent (by `idnumber` or name+parent)    |
+| `createCourse`        | supported   | Idempotent by `shortname`                    |
+| `createUser`          | supported   | Idempotent by `username`                     |
+| `createUsers`         | supported   | Loops over `createUser`                      |
+| `enrolUser`           | supported   | Manual enrolment, idempotent                 |
+| `installMoodle`       | no-op       | Moodle is installed by the container startup |
+| `login`               | no-op       | Browser-only; not applicable server-side     |
+| `restoreCourse`       | planned     | Recognised; fails clearly until implemented  |
+| `runPhpCode`          | disabled    | Unsafe                                        |
+| `runPhpScript`        | disabled    | Unsafe                                        |
+| `writeFile`           | disabled    | Unsafe by default                            |
+| `unzip`               | disabled    | Unsafe by default                            |
+
+Other recognised Moodle Playground steps (e.g. `addModule`, `createRole`,
+`installLanguagePack`, bulk variants) are reported as **planned** and fail
+clearly rather than being silently ignored. Truly unknown steps fail with an
+"unknown step type" error.
+
+### Step examples
+
+=== "setConfig / setConfigs"
+
+    ```json
+    { "step": "setConfig", "name": "debug", "value": 32767 }
+    ```
+
+    ```json
+    { "step": "setConfigs", "values": { "debug": 32767, "debugdisplay": 1 } }
+    ```
+
+=== "setAdminAccount"
+
+    ```json
+    {
+      "step": "setAdminAccount",
+      "username": "admin",
+      "password": "ChangeMe123!",
+      "email": "admin@example.com"
+    }
+    ```
+
+=== "installMoodlePlugin"
+
+    ```json
+    { "step": "installMoodlePlugin", "source": "@pluginZip" }
+    ```
+
+    ```json
+    { "step": "installMoodlePlugin", "zipUrl": "https://example.com/plugin.zip" }
+    ```
+
+=== "createCourse / enrolUser"
+
+    ```json
+    { "step": "createCourse", "fullname": "Demo course", "shortname": "DEMO101", "category": "Demo" }
+    ```
+
+    ```json
+    { "step": "enrolUser", "username": "student1", "course": "DEMO101", "role": "student" }
+    ```
+
+## Idempotency
+
+After a blueprint is applied successfully, a marker is written under:
+
+```text
+/var/www/moodledata/.blueprints/<sha256>.done
+```
+
+The hash is computed over the **normalised blueprint content** (key order and
+whitespace independent). On the next start:
+
+- if the marker exists and `MOODLE_BLUEPRINT_FORCE` is not `true`, the runner
+  prints `Blueprint already applied: <hash>` and exits successfully without
+  reapplying;
+- if `MOODLE_BLUEPRINT_FORCE=true`, it reapplies.
+
+!!! note "Hash limitation"
+    The hash covers the declarative blueprint JSON only. It does **not** include
+    the bytes of bundled or remote resources, so changing a referenced resource
+    without editing the blueprint will not change the hash. Use
+    `MOODLE_BLUEPRINT_FORCE=true` to force reapplication in that case.
+
+Individual steps are also idempotent where it matters (categories by
+`idnumber`/name, courses by `shortname`, users by `username`, enrolments are not
+duplicated), so reapplying a blueprint converges rather than duplicating data.
+
+## Security
+
+The runner enforces safe defaults in a central `SecurityPolicy`:
+
+- no `eval` and no arbitrary code execution;
+- shelling out uses `escapeshellarg()` — no command interpolation of user input;
+- passwords are never logged;
+- remote resources respect `MOODLE_BLUEPRINT_ALLOW_REMOTE_RESOURCES` and are
+  bounded by `MOODLE_BLUEPRINT_MAX_RESOURCE_SIZE` (http/https only);
+- ZIP extraction is performed entry-by-entry with ZIP-slip protection; symlink
+  entries are never honoured;
+- bundle resource paths cannot escape the bundle directory (no `..`, no absolute
+  paths, `__MACOSX` ignored);
+- plugin installs are restricted to allowlisted Moodle directories;
+- unsafe steps are disabled by default and are not implemented in this version.
+
+## Bundles
+
+A bundle is a self-contained directory or ZIP containing `blueprint.json` plus
+the resources it references (inspired by WordPress Playground Blueprint
+Bundles). `blueprint.json` may sit at the bundle root or exactly one directory
+deep; the `__MACOSX` folder is ignored and multiple candidates are an error.
+
+```text
+my-moodle-blueprint/
+├── blueprint.json
+└── plugins/
+    └── mod_example.zip
+```
+
+```json
+{
+  "resources": {
+    "examplePlugin": {
+      "bundled": "plugins/mod_example.zip"
+    }
+  },
+  "steps": [
+    {
+      "step": "installMoodlePlugin",
+      "source": "@examplePlugin"
+    }
+  ]
+}
+```
+
+!!! note "Remote bundle URLs are future work"
+    `MOODLE_BLUEPRINT_BUNDLE` accepts a **local** directory or ZIP only.
+    Downloading a remote bundle ZIP is not implemented yet; use
+    `MOODLE_BLUEPRINT_URL` for a remote single-file blueprint, or fetch the
+    bundle into the container yourself.
+
+## docker-compose example
+
+```yaml
+services:
+  moodle:
+    image: erseco/alpine-moodle:latest
+    ports:
+      - "8080:8080"
+    environment:
+      MOODLE_DATABASE_TYPE: sqlite3
+      MOODLE_USERNAME: admin
+      MOODLE_PASSWORD: ChangeMe123!
+      MOODLE_EMAIL: admin@example.com
+      MOODLE_SITENAME: "Blueprint Demo"
+      MOODLE_BLUEPRINT: /blueprints/demo.blueprint.json
+    volumes:
+      - moodledata:/var/www/moodledata
+      - ./demo.blueprint.json:/blueprints/demo.blueprint.json:ro
+
+volumes:
+  moodledata:
+```
+
+A copy-pasteable [`demo.blueprint.json`](examples/demo.blueprint.json) lives in
+`docs/examples/`.
+
+## Manual validation
+
+The blueprint runs after Moodle installation/upgrade. To try it end-to-end:
+
+```sh
+docker build -t alpine-moodle-blueprint-test .
+docker run --rm \
+  -p 8080:8080 \
+  -e MOODLE_DATABASE_TYPE=sqlite3 \
+  -e MOODLE_USERNAME=admin \
+  -e MOODLE_PASSWORD=ChangeMe123! \
+  -e MOODLE_EMAIL=admin@example.com \
+  -e MOODLE_SITENAME="Blueprint Demo" \
+  -e MOODLE_BLUEPRINT=/blueprints/demo.blueprint.json \
+  -v "$PWD/docs/examples/demo.blueprint.json:/blueprints/demo.blueprint.json:ro" \
+  alpine-moodle-blueprint-test
+```
+
+You can also validate a blueprint without applying it (no Moodle bootstrap):
+
+```sh
+docker run --rm \
+  -e MOODLE_BLUEPRINT=/blueprints/demo.blueprint.json \
+  -v "$PWD/docs/examples/demo.blueprint.json:/blueprints/demo.blueprint.json:ro" \
+  alpine-moodle-blueprint-test moodle-blueprint validate
+```
+
+## Tests
+
+The runner ships with dependency-free PHP unit tests plus lint/shell checks:
+
+```sh
+tests/blueprint/run.sh
+```
+
+This lints every PHP file, syntax-checks the entrypoint hook, and runs unit
+tests for the parser, security policy, resource resolver, archive safety,
+bundle detection, step registry and idempotency markers.

--- a/docs/examples/bundle/blueprint.json
+++ b/docs/examples/bundle/blueprint.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ateeducacion/moodle-playground/main/assets/blueprints/blueprint-schema.json",
+  "preferredVersions": {
+    "php": "8.3",
+    "moodle": "5.0"
+  },
+  "resources": {
+    "examplePlugin": {
+      "bundled": "plugins/mod_example.zip"
+    }
+  },
+  "steps": [
+    {
+      "step": "installMoodlePlugin",
+      "source": "@examplePlugin"
+    }
+  ]
+}

--- a/docs/examples/bundle/plugins/README.md
+++ b/docs/examples/bundle/plugins/README.md
@@ -1,0 +1,21 @@
+# Bundle plugins directory
+
+This directory illustrates the layout of a Moodle blueprint **bundle**: a
+self-contained directory (or ZIP) holding a `blueprint.json` plus the resources
+it references.
+
+Place plugin ZIPs here and reference them from `blueprint.json` with a
+`bundled` resource descriptor, e.g.:
+
+```json
+{ "bundled": "plugins/mod_example.zip" }
+```
+
+The example `blueprint.json` in the parent directory expects a file named
+`mod_example.zip` here. No binary ZIP is committed to the repository — drop your
+own plugin ZIP in this folder, then point `MOODLE_BLUEPRINT_BUNDLE` at the
+bundle directory (or zip it up first):
+
+```sh
+MOODLE_BLUEPRINT_BUNDLE=/blueprints/bundle/
+```

--- a/docs/examples/demo.blueprint.json
+++ b/docs/examples/demo.blueprint.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ateeducacion/moodle-playground/main/assets/blueprints/blueprint-schema.json",
+  "preferredVersions": {
+    "php": "8.3",
+    "moodle": "5.0"
+  },
+  "landingPage": "/course/index.php",
+  "steps": [
+    {
+      "step": "setConfig",
+      "name": "debug",
+      "value": 32767
+    },
+    {
+      "step": "createCategory",
+      "name": "Blueprint demo",
+      "idnumber": "blueprint-demo"
+    },
+    {
+      "step": "createCourse",
+      "fullname": "Blueprint demo course",
+      "shortname": "BLUEPRINT101",
+      "category": "blueprint-demo"
+    },
+    {
+      "step": "createUser",
+      "username": "student1",
+      "password": "ChangeMe123!",
+      "email": "student1@example.com",
+      "firstname": "Student",
+      "lastname": "One"
+    },
+    {
+      "step": "enrolUser",
+      "username": "student1",
+      "course": "BLUEPRINT101",
+      "role": "student"
+    }
+  ]
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
   - Persistence & Volumes: persistence.md
   - Configuration: configuration.md
   - SQLite Mode: sqlite.md
+  - Blueprints: blueprints.md
   - PHP 8.4 (opt-in): php84.md
   - Upgrading: upgrading.md
   - Troubleshooting: troubleshooting.md

--- a/rootfs/docker-entrypoint-init.d/03-apply-blueprint.sh
+++ b/rootfs/docker-entrypoint-init.d/03-apply-blueprint.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+#
+# Apply a Moodle Playground-compatible blueprint after Moodle has been
+# installed/upgraded (this hook sorts after 02-configure-moodle.sh).
+#
+# This is an additional declarative provisioning layer; it never replaces the
+# environment-variable configuration. When no blueprint variable is set the
+# hook exits successfully without doing anything.
+#
+# Behaviour on failure is controlled by MOODLE_BLUEPRINT_ON_ERROR:
+#   abort (default) -> fail container startup if blueprint application fails
+#   warn            -> print a warning and continue startup
+#
+set -eu
+
+# Skip quickly when no blueprint source is configured.
+if [ -z "${MOODLE_BLUEPRINT:-}" ] && \
+   [ -z "${MOODLE_BLUEPRINT_URL:-}" ] && \
+   [ -z "${MOODLE_BLUEPRINT_BUNDLE:-}" ]; then
+    echo "[blueprint] No blueprint variable set; skipping."
+    exit 0
+fi
+
+on_error="${MOODLE_BLUEPRINT_ON_ERROR:-abort}"
+case "$on_error" in
+    abort|warn) ;;
+    *)
+        echo "[blueprint] ERROR: invalid MOODLE_BLUEPRINT_ON_ERROR='$on_error' (expected 'abort' or 'warn')." >&2
+        exit 1
+        ;;
+esac
+
+echo "[blueprint] Applying Moodle blueprint..."
+
+# The runner reads the MOODLE_BLUEPRINT* environment variables directly.
+if /usr/local/bin/moodle-blueprint apply; then
+    echo "[blueprint] Blueprint applied."
+    exit 0
+fi
+
+# Application failed: respect the configured error policy.
+if [ "$on_error" = "warn" ]; then
+    echo "[blueprint] WARNING: blueprint application failed; continuing startup (MOODLE_BLUEPRINT_ON_ERROR=warn)." >&2
+    exit 0
+fi
+
+echo "[blueprint] ERROR: blueprint application failed; aborting startup (MOODLE_BLUEPRINT_ON_ERROR=abort)." >&2
+exit 1

--- a/rootfs/usr/local/bin/moodle-blueprint
+++ b/rootfs/usr/local/bin/moodle-blueprint
@@ -1,0 +1,172 @@
+#!/usr/bin/env php
+<?php
+/**
+ * moodle-blueprint — apply Moodle Playground-compatible blueprint.json files.
+ *
+ * Usage:
+ *   moodle-blueprint apply      Apply a blueprint (bootstraps Moodle).
+ *   moodle-blueprint validate   Parse and classify a blueprint without applying.
+ *   moodle-blueprint help       Show this help.
+ *
+ * Inputs are taken from environment variables (see below) and may be overridden
+ * with flags. Source precedence: bundle > file > url.
+ *
+ *   MOODLE_BLUEPRINT                      Path to a blueprint.json file
+ *   MOODLE_BLUEPRINT_URL                  Remote URL to a blueprint.json file
+ *   MOODLE_BLUEPRINT_BUNDLE               Path to a bundle directory or ZIP
+ *   MOODLE_BLUEPRINT_FORCE                Reapply even if already applied (false)
+ *   MOODLE_BLUEPRINT_ALLOW_REMOTE_RESOURCES   Allow url resources (true)
+ *   MOODLE_BLUEPRINT_ALLOW_UNSAFE_STEPS   Allow unsafe steps if implemented (false)
+ *   MOODLE_BLUEPRINT_MAX_RESOURCE_SIZE    Max remote resource size (50M)
+ *
+ * This is a CLI-only tool; it refuses to run when served over HTTP.
+ */
+
+use MoodleBlueprint\BlueprintException;
+use MoodleBlueprint\BlueprintRunner;
+use MoodleBlueprint\Logger;
+use MoodleBlueprint\SecurityPolicy;
+
+define('CLI_SCRIPT', true);
+
+// Extra execution prevention — never serve this over the web.
+if (isset($_SERVER['REMOTE_ADDR'])) {
+    exit(1);
+}
+
+$libDir = getenv('MOODLE_BLUEPRINT_LIB') ?: '/usr/local/lib/moodle-blueprint';
+require $libDir . '/autoload.php';
+
+$logger = new Logger();
+
+/**
+ * Read a boolean-ish environment variable.
+ */
+function blueprint_env_bool(string $name, bool $default): bool
+{
+    $value = getenv($name);
+    if ($value === false || $value === '') {
+        return $default;
+    }
+    $parsed = filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+    return $parsed === null ? $default : $parsed;
+}
+
+/**
+ * Parse "--key=value" / "--flag" arguments into a map.
+ *
+ * @param array<int,string> $argv
+ * @return array<string,string|bool>
+ */
+function blueprint_parse_flags(array $argv): array
+{
+    $flags = [];
+    foreach ($argv as $arg) {
+        if (strncmp($arg, '--', 2) !== 0) {
+            continue;
+        }
+        $arg = substr($arg, 2);
+        if (strpos($arg, '=') !== false) {
+            [$k, $v] = explode('=', $arg, 2);
+            $flags[$k] = $v;
+        } else {
+            $flags[$arg] = true;
+        }
+    }
+    return $flags;
+}
+
+$command = $argv[1] ?? 'apply';
+$flags = blueprint_parse_flags(array_slice($argv, 2));
+
+if ($command === 'help' || $command === '--help' || $command === '-h') {
+    fwrite(STDOUT, "Usage: moodle-blueprint [apply|validate|help]\n");
+    fwrite(STDOUT, "See the header of this script and docs/blueprints.md for details.\n");
+    exit(0);
+}
+
+// Resolve the blueprint sources (flags override environment).
+$bundle = isset($flags['bundle']) && is_string($flags['bundle']) ? $flags['bundle'] : (getenv('MOODLE_BLUEPRINT_BUNDLE') ?: null);
+$file   = isset($flags['file']) && is_string($flags['file']) ? $flags['file'] : (getenv('MOODLE_BLUEPRINT') ?: null);
+$url    = isset($flags['url']) && is_string($flags['url']) ? $flags['url'] : (getenv('MOODLE_BLUEPRINT_URL') ?: null);
+
+if (($bundle === null || $bundle === '') && ($file === null || $file === '') && ($url === null || $url === '')) {
+    $logger->info('No blueprint variable set; nothing to apply.');
+    exit(0);
+}
+
+$force        = isset($flags['force']) ? true : blueprint_env_bool('MOODLE_BLUEPRINT_FORCE', false);
+$allowRemote  = isset($flags['no-remote']) ? false : blueprint_env_bool('MOODLE_BLUEPRINT_ALLOW_REMOTE_RESOURCES', true);
+$allowUnsafe  = isset($flags['allow-unsafe']) ? true : blueprint_env_bool('MOODLE_BLUEPRINT_ALLOW_UNSAFE_STEPS', false);
+$maxSizeStr   = isset($flags['max-size']) && is_string($flags['max-size']) ? $flags['max-size'] : (getenv('MOODLE_BLUEPRINT_MAX_RESOURCE_SIZE') ?: '50M');
+
+$moodleRoot = isset($flags['moodle-root']) && is_string($flags['moodle-root']) ? $flags['moodle-root'] : '/var/www/html';
+$dataRoot   = isset($flags['data-root']) && is_string($flags['data-root']) ? $flags['data-root'] : '/var/www/moodledata';
+
+// Create an isolated working directory and clean it up on exit.
+$workDir = isset($flags['work-dir']) && is_string($flags['work-dir'])
+    ? $flags['work-dir']
+    : sys_get_temp_dir() . '/moodle-blueprint.' . getmypid() . '.' . substr(sha1((string) mt_rand()), 0, 8);
+if (!is_dir($workDir) && !mkdir($workDir, 0700, true) && !is_dir($workDir)) {
+    $logger->error('Unable to create working directory: ' . $workDir);
+    exit(1);
+}
+register_shutdown_function(static function () use ($workDir) {
+    if (is_dir($workDir)) {
+        $it = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($workDir, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($it as $item) {
+            $item->isDir() ? @rmdir($item->getPathname()) : @unlink($item->getPathname());
+        }
+        @rmdir($workDir);
+    }
+});
+
+try {
+    $maxSize = SecurityPolicy::parseSize($maxSizeStr);
+    $policy = new SecurityPolicy($allowRemote, $allowUnsafe, $maxSize, [$moodleRoot]);
+
+    if ($command === 'validate') {
+        $runner = new BlueprintRunner($logger, $policy, $moodleRoot, $dataRoot, $workDir, $force);
+        $summary = $runner->validate($bundle ?: null, $file ?: null, $url ?: null);
+        foreach ($summary as $kind => $count) {
+            $logger->info(sprintf('  %s: %d step(s)', $kind, $count));
+        }
+        exit(0);
+    }
+
+    if ($command !== 'apply') {
+        $logger->error('Unknown command: ' . $command);
+        exit(1);
+    }
+
+    // Apply requires a configured Moodle: bootstrap it so the create* steps can
+    // use the Moodle PHP API and so we read the real data/code roots.
+    $configfile = $moodleRoot . '/config.php';
+    if (!is_file($configfile)) {
+        $logger->error('Moodle is not configured yet (config.php missing); cannot apply blueprint.');
+        exit(1);
+    }
+    require($configfile);
+    if (isset($CFG->libdir) && is_file($CFG->libdir . '/clilib.php')) {
+        require_once($CFG->libdir . '/clilib.php');
+    }
+    if (isset($CFG->dirroot)) {
+        $moodleRoot = $CFG->dirroot;
+    }
+    if (isset($CFG->dataroot)) {
+        $dataRoot = $CFG->dataroot;
+    }
+
+    $runner = new BlueprintRunner($logger, $policy, $moodleRoot, $dataRoot, $workDir, $force);
+    $runner->apply($bundle ?: null, $file ?: null, $url ?: null);
+    exit(0);
+} catch (BlueprintException $e) {
+    $logger->error($e->describe());
+    exit(1);
+} catch (\Throwable $e) {
+    $logger->error($e->getMessage());
+    exit(1);
+}

--- a/rootfs/usr/local/lib/moodle-blueprint/Archive.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/Archive.php
@@ -12,6 +12,9 @@ namespace MoodleBlueprint;
  */
 class Archive
 {
+    /** Maximum number of entries an archive may contain (inode-exhaustion guard). */
+    private const MAX_ENTRIES = 20000;
+
     /**
      * Return true if $path is a readable ZIP archive.
      */
@@ -50,6 +53,18 @@ class Archive
             throw new BlueprintException(sprintf('Unable to create extraction directory "%s".', $destDir));
         }
 
+        // Guard against zip bombs and inode exhaustion. The cumulative byte
+        // counter during extraction is authoritative; the up-front declared-size
+        // check below rejects obvious bombs before any bytes are written.
+        $maxBytes = $policy->maxArchiveSize();
+        if ($zip->numFiles > self::MAX_ENTRIES) {
+            $zip->close();
+            throw new BlueprintException(sprintf('Archive has too many entries (%d > %d).', $zip->numFiles, self::MAX_ENTRIES));
+        }
+
+        $declaredTotal = 0;
+        $writtenTotal = 0;
+
         try {
             for ($i = 0; $i < $zip->numFiles; $i++) {
                 $name = $zip->getNameIndex($i);
@@ -74,6 +89,18 @@ class Archive
                     continue;
                 }
 
+                // Reject obvious bombs using the declared uncompressed size.
+                $stat = $zip->statIndex($i);
+                if (is_array($stat) && isset($stat['size'])) {
+                    $declaredTotal += (int) $stat['size'];
+                    if ($declaredTotal > $maxBytes) {
+                        throw new BlueprintException(sprintf(
+                            'Archive decompresses to more than the %d byte limit (possible zip bomb).',
+                            $maxBytes
+                        ));
+                    }
+                }
+
                 $parent = dirname($target);
                 if (!is_dir($parent) && !mkdir($parent, 0775, true) && !is_dir($parent)) {
                     throw new BlueprintException(sprintf('Unable to create directory "%s".', $parent));
@@ -88,7 +115,30 @@ class Archive
                     fclose($in);
                     throw new BlueprintException(sprintf('Unable to write extracted file "%s".', $clean));
                 }
-                stream_copy_to_stream($in, $out);
+
+                // Copy in bounded chunks, enforcing the cumulative cap so a lying
+                // header cannot bypass the declared-size check above.
+                while (!feof($in)) {
+                    $chunk = fread($in, 65536);
+                    if ($chunk === false) {
+                        break;
+                    }
+                    $writtenTotal += strlen($chunk);
+                    if ($writtenTotal > $maxBytes) {
+                        fclose($in);
+                        fclose($out);
+                        @unlink($target);
+                        throw new BlueprintException(sprintf(
+                            'Archive decompresses to more than the %d byte limit (possible zip bomb).',
+                            $maxBytes
+                        ));
+                    }
+                    if (fwrite($out, $chunk) === false) {
+                        fclose($in);
+                        fclose($out);
+                        throw new BlueprintException(sprintf('Unable to write extracted file "%s".', $clean));
+                    }
+                }
                 fclose($in);
                 fclose($out);
             }

--- a/rootfs/usr/local/lib/moodle-blueprint/Archive.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/Archive.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace MoodleBlueprint;
+
+/**
+ * Safe ZIP extraction.
+ *
+ * Extraction is performed entry-by-entry, writing only regular files and
+ * directories whose destination has been validated to stay inside the target
+ * directory. Symlink entries are never honoured, which — combined with the
+ * SecurityPolicy path checks — defeats ZIP slip and symlink-escape attacks.
+ */
+class Archive
+{
+    /**
+     * Return true if $path is a readable ZIP archive.
+     */
+    public static function isZip(string $path): bool
+    {
+        if (!class_exists('ZipArchive')) {
+            return false;
+        }
+        $zip = new \ZipArchive();
+        $opened = $zip->open($path);
+        if ($opened === true) {
+            $zip->close();
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Safely extract a ZIP archive into $destDir.
+     *
+     * @throws BlueprintException on any unsafe entry or extraction failure.
+     */
+    public static function extract(SecurityPolicy $policy, string $zipPath, string $destDir): void
+    {
+        if (!class_exists('ZipArchive')) {
+            throw new BlueprintException('The PHP zip extension (ZipArchive) is required to extract archives.');
+        }
+
+        $zip = new \ZipArchive();
+        if ($zip->open($zipPath) !== true) {
+            throw new BlueprintException(sprintf('Unable to open ZIP archive "%s".', $zipPath));
+        }
+
+        if (!is_dir($destDir) && !mkdir($destDir, 0775, true) && !is_dir($destDir)) {
+            $zip->close();
+            throw new BlueprintException(sprintf('Unable to create extraction directory "%s".', $destDir));
+        }
+
+        try {
+            for ($i = 0; $i < $zip->numFiles; $i++) {
+                $name = $zip->getNameIndex($i);
+                if ($name === false || $name === '') {
+                    continue;
+                }
+
+                // The macOS archiver adds a __MACOSX metadata tree; ignore it.
+                if ($name === '__MACOSX' || strncmp($name, '__MACOSX/', 9) === 0) {
+                    continue;
+                }
+
+                $isDir = substr($name, -1) === '/';
+                $clean = rtrim($name, '/');
+                $policy->assertSafeArchiveEntry($clean);
+                $target = $policy->safeJoin($destDir, $clean);
+
+                if ($isDir) {
+                    if (!is_dir($target) && !mkdir($target, 0775, true) && !is_dir($target)) {
+                        throw new BlueprintException(sprintf('Unable to create directory "%s".', $clean));
+                    }
+                    continue;
+                }
+
+                $parent = dirname($target);
+                if (!is_dir($parent) && !mkdir($parent, 0775, true) && !is_dir($parent)) {
+                    throw new BlueprintException(sprintf('Unable to create directory "%s".', $parent));
+                }
+
+                $in = $zip->getStream($name);
+                if ($in === false) {
+                    throw new BlueprintException(sprintf('Unable to read archive entry "%s".', $name));
+                }
+                $out = fopen($target, 'wb');
+                if ($out === false) {
+                    fclose($in);
+                    throw new BlueprintException(sprintf('Unable to write extracted file "%s".', $clean));
+                }
+                stream_copy_to_stream($in, $out);
+                fclose($in);
+                fclose($out);
+            }
+        } finally {
+            $zip->close();
+        }
+    }
+}

--- a/rootfs/usr/local/lib/moodle-blueprint/Blueprint.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/Blueprint.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace MoodleBlueprint;
+
+/**
+ * Parsed, constant-substituted blueprint.
+ *
+ * Holds the decoded blueprint data and exposes typed accessors for the parts
+ * the runner cares about. Unknown top-level fields are preserved verbatim in
+ * {@see data()} so forward-compatible blueprints do not fail to load.
+ */
+class Blueprint
+{
+    /** @var array<string,mixed> */
+    private $data;
+
+    /**
+     * @param array<string,mixed> $data Decoded + substituted blueprint data.
+     */
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function data(): array
+    {
+        return $this->data;
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    public function steps(): array
+    {
+        return $this->data['steps'] ?? [];
+    }
+
+    /**
+     * Top-level named resources map.
+     *
+     * @return array<string,mixed>
+     */
+    public function resources(): array
+    {
+        $resources = $this->data['resources'] ?? [];
+        return is_array($resources) ? $resources : [];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function constants(): array
+    {
+        $constants = $this->data['constants'] ?? [];
+        return is_array($constants) ? $constants : [];
+    }
+
+    public function landingPage(): ?string
+    {
+        return isset($this->data['landingPage']) ? (string) $this->data['landingPage'] : null;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function preferredVersions(): array
+    {
+        $pv = $this->data['preferredVersions'] ?? [];
+        return is_array($pv) ? $pv : [];
+    }
+
+    /**
+     * Stable SHA-256 over the canonical (recursively key-sorted) blueprint
+     * content, used as the idempotency marker name.
+     *
+     * NOTE: this hashes the declarative blueprint content only. It does not
+     * incorporate the bytes of bundled/remote resources, so changing a
+     * referenced resource without editing the blueprint will not change the
+     * hash. See docs/blueprints.md for this documented limitation.
+     */
+    public function canonicalHash(): string
+    {
+        return hash('sha256', self::canonicalize($this->data));
+    }
+
+    /**
+     * Produce a deterministic JSON encoding by recursively sorting array keys.
+     *
+     * @param mixed $value
+     */
+    private static function canonicalize($value): string
+    {
+        if (is_array($value)) {
+            $isList = array_keys($value) === range(0, count($value) - 1);
+            if (!$isList) {
+                ksort($value);
+            }
+            $parts = [];
+            foreach ($value as $k => $v) {
+                $parts[] = json_encode((string) $k) . ':' . self::canonicalize($v);
+            }
+            return ($isList ? '[' : '{') . implode(',', $parts) . ($isList ? ']' : '}');
+        }
+        return json_encode($value);
+    }
+}

--- a/rootfs/usr/local/lib/moodle-blueprint/BlueprintException.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/BlueprintException.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace MoodleBlueprint;
+
+/**
+ * Structured error raised while parsing or applying a blueprint.
+ *
+ * Carries optional step context (index + name) so the runner can produce
+ * actionable messages such as "step 3 (installMoodlePlugin): ...".
+ */
+class BlueprintException extends \RuntimeException
+{
+    /** @var int|null Zero-based index of the failing step, if applicable. */
+    private $stepIndex;
+
+    /** @var string|null Name of the failing step, if applicable. */
+    private $stepName;
+
+    public function __construct(string $message, ?int $stepIndex = null, ?string $stepName = null, ?\Throwable $previous = null)
+    {
+        $this->stepIndex = $stepIndex;
+        $this->stepName = $stepName;
+        parent::__construct($message, 0, $previous);
+    }
+
+    public function getStepIndex(): ?int
+    {
+        return $this->stepIndex;
+    }
+
+    public function getStepName(): ?string
+    {
+        return $this->stepName;
+    }
+
+    /**
+     * Human-readable message prefixed with the failing step when known.
+     */
+    public function describe(): string
+    {
+        if ($this->stepIndex !== null) {
+            $name = $this->stepName !== null ? $this->stepName : 'unknown';
+            return sprintf('step %d (%s): %s', $this->stepIndex, $name, $this->getMessage());
+        }
+        return $this->getMessage();
+    }
+}

--- a/rootfs/usr/local/lib/moodle-blueprint/BlueprintParser.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/BlueprintParser.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace MoodleBlueprint;
+
+/**
+ * Parses and validates blueprint JSON.
+ *
+ * Responsibilities (the "declaration + validation" phases, kept separate from
+ * resource resolution and step execution):
+ *   - decode JSON, failing clearly on syntax errors;
+ *   - require a `steps` array, each entry carrying a non-empty `step` name;
+ *   - substitute `{{KEY}}` constants throughout the structure;
+ *   - preserve unknown top-level fields without failing.
+ */
+class BlueprintParser
+{
+    /**
+     * Parse a blueprint from a JSON string.
+     */
+    public function parse(string $json): Blueprint
+    {
+        $data = json_decode($json, true);
+        if ($data === null && json_last_error() !== JSON_ERROR_NONE) {
+            throw new BlueprintException('Invalid blueprint JSON: ' . json_last_error_msg());
+        }
+        if (!is_array($data) || array_keys($data) === range(0, count($data) - 1)) {
+            throw new BlueprintException('Blueprint must be a JSON object.');
+        }
+
+        $constants = [];
+        if (isset($data['constants'])) {
+            if (!is_array($data['constants'])) {
+                throw new BlueprintException('Blueprint "constants" must be an object.');
+            }
+            $constants = $data['constants'];
+        }
+
+        $data = self::substituteConstants($data, $constants);
+
+        if (!array_key_exists('steps', $data)) {
+            throw new BlueprintException('Blueprint must contain a "steps" array.');
+        }
+        if (!is_array($data['steps']) || (count($data['steps']) > 0 && array_keys($data['steps']) !== range(0, count($data['steps']) - 1))) {
+            throw new BlueprintException('Blueprint "steps" must be an array.');
+        }
+
+        foreach ($data['steps'] as $index => $step) {
+            if (!is_array($step)) {
+                throw new BlueprintException('Each step must be an object.', (int) $index);
+            }
+            if (!isset($step['step']) || !is_string($step['step']) || $step['step'] === '') {
+                throw new BlueprintException('Each step must have a non-empty "step" name.', (int) $index);
+            }
+        }
+
+        return new Blueprint($data);
+    }
+
+    /**
+     * Parse a blueprint from a file path.
+     */
+    public function parseFile(string $path): Blueprint
+    {
+        if (!is_file($path)) {
+            throw new BlueprintException(sprintf('Blueprint file not found: %s', $path));
+        }
+        $json = file_get_contents($path);
+        if ($json === false) {
+            throw new BlueprintException(sprintf('Unable to read blueprint file: %s', $path));
+        }
+        return $this->parse($json);
+    }
+
+    /**
+     * Recursively replace `{{KEY}}` placeholders in every string value using
+     * the supplied constants map. Unknown placeholders are left untouched.
+     *
+     * @param mixed $value
+     * @param array<string,mixed> $constants
+     * @return mixed
+     */
+    public static function substituteConstants($value, array $constants)
+    {
+        if (is_string($value)) {
+            return preg_replace_callback('/\{\{(\w+)\}\}/u', static function ($m) use ($constants) {
+                return array_key_exists($m[1], $constants) ? (string) $constants[$m[1]] : $m[0];
+            }, $value);
+        }
+        if (is_array($value)) {
+            $out = [];
+            foreach ($value as $k => $v) {
+                $out[$k] = self::substituteConstants($v, $constants);
+            }
+            return $out;
+        }
+        return $value;
+    }
+}

--- a/rootfs/usr/local/lib/moodle-blueprint/BlueprintRunner.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/BlueprintRunner.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace MoodleBlueprint;
+
+/**
+ * Orchestrates applying a blueprint: source selection, parsing, idempotency,
+ * and sequential (fail-fast) step execution.
+ *
+ * Source precedence (matching the documented behaviour):
+ *   1. bundle  (MOODLE_BLUEPRINT_BUNDLE)
+ *   2. file    (MOODLE_BLUEPRINT)
+ *   3. url     (MOODLE_BLUEPRINT_URL)
+ */
+class BlueprintRunner
+{
+    /** @var Logger */
+    private $logger;
+
+    /** @var SecurityPolicy */
+    private $policy;
+
+    /** @var string */
+    private $moodleRoot;
+
+    /** @var string */
+    private $dataRoot;
+
+    /** @var string */
+    private $workDir;
+
+    /** @var bool */
+    private $force;
+
+    public function __construct(
+        Logger $logger,
+        SecurityPolicy $policy,
+        string $moodleRoot,
+        string $dataRoot,
+        string $workDir,
+        bool $force
+    ) {
+        $this->logger = $logger;
+        $this->policy = $policy;
+        $this->moodleRoot = rtrim($moodleRoot, '/');
+        $this->dataRoot = rtrim($dataRoot, '/');
+        $this->workDir = rtrim($workDir, '/');
+        $this->force = $force;
+    }
+
+    /**
+     * Apply a blueprint chosen from the provided sources.
+     *
+     * @return bool True when the blueprint was applied (or already applied).
+     */
+    public function apply(?string $bundle, ?string $file, ?string $url): bool
+    {
+        [$blueprintPath, $bundleRoot] = $this->selectSource($bundle, $file, $url);
+
+        $parser = new BlueprintParser();
+        $blueprint = $parser->parseFile($blueprintPath);
+
+        $hash = $blueprint->canonicalHash();
+        $markerFile = $this->dataRoot . '/.blueprints/' . $hash . '.done';
+        if (!$this->force && is_file($markerFile)) {
+            $this->logger->info('Blueprint already applied: ' . $hash);
+            return true;
+        }
+
+        $resolver = new ResourceResolver($this->policy, $this->workDir, $this->logger, $bundleRoot);
+        $resolver->setNamedResources($blueprint->resources());
+
+        $context = new RunContext(
+            $this->logger,
+            $this->policy,
+            $resolver,
+            $blueprint,
+            $this->moodleRoot,
+            $this->dataRoot,
+            $this->workDir,
+            $this->force
+        );
+
+        $this->runSteps($context, $blueprint);
+
+        $this->writeMarker($markerFile, $hash);
+        $this->logger->info('Blueprint applied successfully: ' . $hash);
+
+        $landing = $blueprint->landingPage();
+        if ($landing !== null && $landing !== '') {
+            $this->logger->info(sprintf('Landing page hint: %s (the Docker runtime does not auto-navigate).', $landing));
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate a blueprint without applying it. Returns a summary of step
+     * classifications. Does not require a bootstrapped Moodle.
+     *
+     * @return array<string,int>
+     */
+    public function validate(?string $bundle, ?string $file, ?string $url): array
+    {
+        [$blueprintPath] = $this->selectSource($bundle, $file, $url);
+        $parser = new BlueprintParser();
+        $blueprint = $parser->parseFile($blueprintPath);
+
+        $registry = new StepRegistry();
+        $summary = [];
+        foreach ($blueprint->steps() as $step) {
+            $kind = $registry->classify((string) $step['step']);
+            $summary[$kind] = ($summary[$kind] ?? 0) + 1;
+        }
+        $this->logger->info('Blueprint is valid. Hash: ' . $blueprint->canonicalHash());
+        return $summary;
+    }
+
+    /**
+     * @return array{0:string,1:?string} [blueprintPath, bundleRoot]
+     */
+    private function selectSource(?string $bundle, ?string $file, ?string $url): array
+    {
+        if ($bundle !== null && $bundle !== '') {
+            $this->logger->info('Blueprint source: bundle (' . $bundle . ')');
+            $opened = Bundle::open($this->policy, $bundle, $this->workDir, $this->logger);
+            return [$opened->blueprintPath(), $opened->root()];
+        }
+        if ($file !== null && $file !== '') {
+            if (!is_file($file)) {
+                throw new BlueprintException(sprintf('Blueprint file not found: %s', $file));
+            }
+            $this->logger->info('Blueprint source: file (' . $file . ')');
+            return [$file, null];
+        }
+        if ($url !== null && $url !== '') {
+            $this->logger->info('Blueprint source: url (' . $url . ')');
+            $contents = Http::download($url, $this->policy->maxResourceSize(), $this->logger, $this->workDir);
+            $dest = $this->workDir . '/blueprint.json';
+            if (file_put_contents($dest, $contents) === false) {
+                throw new BlueprintException('Unable to store the downloaded blueprint.');
+            }
+            return [$dest, null];
+        }
+        throw new BlueprintException('No blueprint source provided.');
+    }
+
+    private function runSteps(RunContext $context, Blueprint $blueprint): void
+    {
+        $registry = new StepRegistry();
+
+        foreach ($blueprint->steps() as $index => $step) {
+            $index = (int) $index;
+            $name = (string) $step['step'];
+            $kind = $registry->classify($name);
+
+            switch ($kind) {
+                case StepRegistry::IMPLEMENTED:
+                    $this->logger->info(sprintf('Step %d: %s', $index, $name));
+                    try {
+                        $registry->handler($name)->run($context, $step, $index);
+                    } catch (BlueprintException $e) {
+                        // Attach step context if the handler did not already.
+                        if ($e->getStepIndex() === null) {
+                            throw new BlueprintException($e->getMessage(), $index, $name, $e);
+                        }
+                        throw $e;
+                    } catch (\Throwable $e) {
+                        throw new BlueprintException($e->getMessage(), $index, $name, $e);
+                    }
+                    break;
+
+                case StepRegistry::NOOP:
+                    $this->logger->info(sprintf(
+                        'Step %d: %s skipped (handled by the container / not applicable to the Docker runtime).',
+                        $index,
+                        $name
+                    ));
+                    break;
+
+                case StepRegistry::PLANNED:
+                    throw new BlueprintException(
+                        sprintf('step "%s" is a recognised Moodle Playground step that is not yet implemented in the Docker runtime (planned).', $name),
+                        $index,
+                        $name
+                    );
+
+                case StepRegistry::UNSAFE:
+                    if (!$this->policy->allowsUnsafeSteps()) {
+                        throw new BlueprintException(
+                            sprintf('unsafe step "%s" is disabled by default (set MOODLE_BLUEPRINT_ALLOW_UNSAFE_STEPS=true to opt in); it is also not implemented in this version.', $name),
+                            $index,
+                            $name
+                        );
+                    }
+                    throw new BlueprintException(
+                        sprintf('unsafe step "%s" is enabled but not implemented in this version.', $name),
+                        $index,
+                        $name
+                    );
+
+                default:
+                    throw new BlueprintException(sprintf('unknown step type "%s".', $name), $index, $name);
+            }
+        }
+    }
+
+    private function writeMarker(string $markerFile, string $hash): void
+    {
+        $dir = dirname($markerFile);
+        if (!is_dir($dir) && !mkdir($dir, 0775, true) && !is_dir($dir)) {
+            throw new BlueprintException(sprintf('Unable to create marker directory "%s".', $dir));
+        }
+        $payload = sprintf("hash=%s\napplied=%s\n", $hash, gmdate('c'));
+        if (file_put_contents($markerFile, $payload) === false) {
+            throw new BlueprintException(sprintf('Unable to write idempotency marker "%s".', $markerFile));
+        }
+    }
+}

--- a/rootfs/usr/local/lib/moodle-blueprint/Bundle.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/Bundle.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace MoodleBlueprint;
+
+/**
+ * A blueprint bundle: a self-contained directory or ZIP archive holding a
+ * `blueprint.json` plus the resources it references (inspired by WordPress
+ * Playground Blueprint Bundles).
+ *
+ * Detection rules (matching the WordPress Playground convention):
+ *   - `blueprint.json` may live at the bundle root, OR
+ *   - exactly one directory deep inside a single top-level folder.
+ *   - The `__MACOSX` metadata directory is ignored during detection.
+ *   - Multiple candidate `blueprint.json` files are an ambiguity error.
+ */
+class Bundle
+{
+    /** @var string Directory containing blueprint.json (resource resolution root). */
+    private $root;
+
+    /** @var string Absolute path to the blueprint.json file. */
+    private $blueprintPath;
+
+    private function __construct(string $root, string $blueprintPath)
+    {
+        $this->root = $root;
+        $this->blueprintPath = $blueprintPath;
+    }
+
+    public function root(): string
+    {
+        return $this->root;
+    }
+
+    public function blueprintPath(): string
+    {
+        return $this->blueprintPath;
+    }
+
+    /**
+     * Open a bundle from a directory or ZIP path. ZIP bundles are extracted
+     * under $workDir/bundle before detection.
+     */
+    public static function open(SecurityPolicy $policy, string $bundlePath, string $workDir, Logger $logger): self
+    {
+        if (is_dir($bundlePath)) {
+            $logger->info('Using bundle directory: ' . $bundlePath);
+            $extracted = rtrim($bundlePath, '/');
+        } elseif (is_file($bundlePath)) {
+            if (!Archive::isZip($bundlePath)) {
+                throw new BlueprintException(sprintf('Bundle "%s" is neither a directory nor a valid ZIP archive.', $bundlePath));
+            }
+            $logger->info('Extracting bundle ZIP: ' . $bundlePath);
+            $extracted = $workDir . '/bundle';
+            Archive::extract($policy, $bundlePath, $extracted);
+        } else {
+            throw new BlueprintException(sprintf('Bundle path "%s" does not exist.', $bundlePath));
+        }
+
+        [$root, $blueprintPath] = self::locateBlueprint($extracted);
+        return new self($root, $blueprintPath);
+    }
+
+    /**
+     * Locate blueprint.json at the bundle root or one directory deep.
+     *
+     * @return array{0:string,1:string} [bundleRoot, blueprintPath]
+     */
+    private static function locateBlueprint(string $root): array
+    {
+        $rootCandidate = $root . '/blueprint.json';
+        if (is_file($rootCandidate)) {
+            return [$root, $rootCandidate];
+        }
+
+        $matches = [];
+        $entries = scandir($root) ?: [];
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..' || $entry === '__MACOSX') {
+                continue;
+            }
+            $sub = $root . '/' . $entry;
+            if (is_dir($sub) && is_file($sub . '/blueprint.json')) {
+                $matches[] = $sub;
+            }
+        }
+
+        if (count($matches) === 1) {
+            return [$matches[0], $matches[0] . '/blueprint.json'];
+        }
+        if (count($matches) > 1) {
+            throw new BlueprintException('Ambiguous bundle: multiple blueprint.json files found one directory deep.');
+        }
+        throw new BlueprintException('No blueprint.json found at the bundle root or one directory deep.');
+    }
+}

--- a/rootfs/usr/local/lib/moodle-blueprint/Frankenstyle.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/Frankenstyle.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace MoodleBlueprint;
+
+/**
+ * Maps a Moodle frankenstyle component (e.g. "mod_quiz") to its install
+ * directory relative to the Moodle code root.
+ *
+ * The plugin-type table mirrors rootfs/docker-entrypoint-init.d/015-copy-plugins.sh
+ * so blueprint plugin installs land in exactly the same places as the existing
+ * PLUGINS mechanism.
+ */
+class Frankenstyle
+{
+    /** @var array<string,string> plugin type => path relative to Moodle root */
+    private const TYPE_DIRS = [
+        'mod'                => 'mod',
+        'block'              => 'blocks',
+        'theme'              => 'theme',
+        'local'              => 'local',
+        'report'             => 'report',
+        'auth'               => 'auth',
+        'filter'             => 'filter',
+        'gradeexport'        => 'grade/export',
+        'gradeimport'        => 'grade/import',
+        'gradereport'        => 'grade/report',
+        'message'            => 'message/output',
+        'tool'               => 'admin/tool',
+        'profilefield'       => 'user/profile/field',
+        'quiz'               => 'mod/quiz/report',
+        'quizaccess'         => 'mod/quiz/accessrule',
+        'plagiarism'         => 'plagiarism',
+        'portfolio'          => 'portfolio',
+        'repository'         => 'repository',
+        'search'             => 'search/engine',
+        'reportbuilder'      => 'reportbuilder/source',
+        'payment'            => 'payment/gateway',
+        'paygw'              => 'payment/gateway',
+        'enrol'              => 'enrol',
+        'assignfeedback'     => 'mod/assign/feedback',
+        'assignsubmission'   => 'mod/assign/submission',
+        'workshopallocation' => 'mod/workshop/allocation',
+        'workshopform'       => 'mod/workshop/form',
+        'workshopeval'       => 'mod/workshop/eval',
+        'question'           => 'question/type',
+        'qtype'              => 'question/type',
+        'qbehaviour'         => 'question/behaviour',
+        'qformat'            => 'question/format',
+        'qbank'              => 'question/bank',
+        'editor'             => 'lib/editor',
+        'tiny'               => 'lib/editor/tiny/plugins',
+        'atto'               => 'lib/editor/atto/plugins',
+        'tinymce'            => 'lib/editor/tinymce/plugins',
+        'availability'       => 'availability/condition',
+        'datafield'          => 'mod/data/field',
+        'datapreset'         => 'mod/data/preset',
+        'scormreport'        => 'mod/scorm/report',
+        'ltisource'          => 'mod/lti/source',
+        'contenttype'        => 'contentbank/contenttype',
+        'format'             => 'course/format',
+        'customfield'        => 'customfield/field',
+        'analytics'          => 'analytics/indicator',
+        'aiprovider'         => 'ai/provider',
+        'aiplacement'        => 'ai/placement',
+        'cachelock'          => 'cache/locks',
+        'cachestore'         => 'cache/stores',
+        'logstore'           => 'admin/tool/log/store',
+        'calendartype'       => 'calendar/type',
+        'media'              => 'media/player',
+        'webservice'         => 'webservice',
+        'coursereport'       => 'course/report',
+        'mlbackend'          => 'lib/mlbackend',
+        'fileconverter'      => 'files/converter',
+        'antivirus'          => 'lib/antivirus',
+        'h5plib'             => 'h5p/h5plib',
+    ];
+
+    /**
+     * Resolve the install directory for a frankenstyle component relative to
+     * the Moodle code root.
+     *
+     * @return string Path relative to the Moodle root (e.g. "mod/quiz").
+     * @throws BlueprintException for unknown plugin types.
+     */
+    public static function relativePath(string $component): string
+    {
+        if (strpos($component, '_') === false) {
+            throw new BlueprintException(sprintf('Invalid frankenstyle component "%s" (expected type_name).', $component));
+        }
+        [$type, $name] = explode('_', $component, 2);
+        if ($type === '' || $name === '' || !preg_match('/^[a-z][a-z0-9_]*$/', $name)) {
+            throw new BlueprintException(sprintf('Invalid frankenstyle component "%s".', $component));
+        }
+        if (!isset(self::TYPE_DIRS[$type])) {
+            throw new BlueprintException(sprintf('Unknown plugin type "%s" for component "%s".', $type, $component));
+        }
+        return self::TYPE_DIRS[$type] . '/' . $name;
+    }
+}

--- a/rootfs/usr/local/lib/moodle-blueprint/Http.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/Http.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace MoodleBlueprint;
+
+/**
+ * Minimal, size-bounded HTTP downloader.
+ *
+ * Uses PHP streams when allow_url_fopen is available and falls back to the
+ * curl binary otherwise. Downloads are always capped at $maxBytes to protect
+ * the container from oversized or runaway responses.
+ */
+class Http
+{
+    /**
+     * Download a URL and return its contents, enforcing a hard byte cap.
+     *
+     * @throws BlueprintException on any failure or when the cap is exceeded.
+     */
+    public static function download(string $url, int $maxBytes, Logger $logger, string $workDir): string
+    {
+        $scheme = strtolower((string) parse_url($url, PHP_URL_SCHEME));
+        if ($scheme !== 'http' && $scheme !== 'https') {
+            throw new BlueprintException(sprintf('Unsupported URL scheme "%s"; only http/https are allowed.', $scheme));
+        }
+
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'GET',
+                'follow_location' => 1,
+                'max_redirects' => 5,
+                'timeout' => 60,
+                'user_agent' => 'alpine-moodle-blueprint/1.0',
+            ],
+            'https' => [
+                'timeout' => 60,
+                'user_agent' => 'alpine-moodle-blueprint/1.0',
+            ],
+        ]);
+
+        $stream = @fopen($url, 'rb', false, $context);
+        if ($stream === false) {
+            return self::downloadWithCurl($url, $maxBytes, $workDir);
+        }
+
+        $contents = '';
+        while (!feof($stream)) {
+            $chunk = fread($stream, 8192);
+            if ($chunk === false) {
+                break;
+            }
+            $contents .= $chunk;
+            if (strlen($contents) > $maxBytes) {
+                fclose($stream);
+                throw new BlueprintException(sprintf(
+                    'Resource "%s" exceeds the %d byte limit (MOODLE_BLUEPRINT_MAX_RESOURCE_SIZE).',
+                    $url,
+                    $maxBytes
+                ));
+            }
+        }
+        fclose($stream);
+
+        if ($contents === '') {
+            throw new BlueprintException(sprintf('Failed to download "%s" (empty response).', $url));
+        }
+        return $contents;
+    }
+
+    /**
+     * Fallback download via the curl binary, bounded by --max-filesize.
+     */
+    private static function downloadWithCurl(string $url, int $maxBytes, string $workDir): string
+    {
+        $tmp = $workDir . '/dl_' . substr(sha1($url), 0, 16) . '.bin';
+        $cmd = sprintf(
+            'curl --silent --show-error --location --fail --max-time 60 --max-filesize %d --output %s %s 2>&1',
+            $maxBytes,
+            escapeshellarg($tmp),
+            escapeshellarg($url)
+        );
+        exec($cmd, $output, $status);
+        if ($status !== 0 || !is_file($tmp)) {
+            throw new BlueprintException(sprintf(
+                'Failed to download "%s": %s',
+                $url,
+                trim(implode("\n", $output))
+            ));
+        }
+        $contents = file_get_contents($tmp);
+        @unlink($tmp);
+        if ($contents === false) {
+            throw new BlueprintException(sprintf('Failed to read downloaded file from "%s".', $url));
+        }
+        if (strlen($contents) > $maxBytes) {
+            throw new BlueprintException(sprintf('Resource "%s" exceeds the %d byte limit.', $url, $maxBytes));
+        }
+        return $contents;
+    }
+}

--- a/rootfs/usr/local/lib/moodle-blueprint/Logger.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/Logger.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace MoodleBlueprint;
+
+/**
+ * Tiny stdout/stderr logger with a consistent prefix.
+ *
+ * The runner never logs secret values directly; helpers here exist so callers
+ * can scrub sensitive fields (passwords, tokens) before emitting a message.
+ */
+class Logger
+{
+    /** @var string Prefix prepended to every line. */
+    private $prefix;
+
+    /** Field names whose values must never be printed. */
+    private const SECRET_KEYS = ['password', 'pass', 'pwd', 'secret', 'token', 'apikey', 'api_key', 'auth'];
+
+    public function __construct(string $prefix = '[blueprint]')
+    {
+        $this->prefix = $prefix;
+    }
+
+    public function info(string $message): void
+    {
+        fwrite(STDOUT, $this->prefix . ' ' . $message . "\n");
+    }
+
+    public function warn(string $message): void
+    {
+        fwrite(STDERR, $this->prefix . ' WARNING: ' . $message . "\n");
+    }
+
+    public function error(string $message): void
+    {
+        fwrite(STDERR, $this->prefix . ' ERROR: ' . $message . "\n");
+    }
+
+    /**
+     * Return a redacted copy of an associative array safe for logging.
+     *
+     * Any key that looks like a secret has its value replaced with "***".
+     *
+     * @param array<string,mixed> $data
+     * @return array<string,mixed>
+     */
+    public static function redact(array $data): array
+    {
+        $safe = [];
+        foreach ($data as $key => $value) {
+            if (is_string($key) && in_array(strtolower($key), self::SECRET_KEYS, true)) {
+                $safe[$key] = '***';
+            } elseif (is_array($value)) {
+                $safe[$key] = self::redact($value);
+            } else {
+                $safe[$key] = $value;
+            }
+        }
+        return $safe;
+    }
+}

--- a/rootfs/usr/local/lib/moodle-blueprint/ResolvedResource.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/ResolvedResource.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace MoodleBlueprint;
+
+/**
+ * A resolved resource: the bytes a step needs, available either as an in-memory
+ * string or as a path to a real file (materialised on demand).
+ */
+class ResolvedResource
+{
+    /** @var string|null In-memory contents, when known. */
+    private $contents;
+
+    /** @var string|null Path to a file holding the contents, when known. */
+    private $path;
+
+    /** @var string Directory used to materialise temporary files. */
+    private $workDir;
+
+    /** @var string A label used for nicer log/error messages. */
+    private $label;
+
+    private function __construct(string $workDir, string $label)
+    {
+        $this->workDir = $workDir;
+        $this->label = $label;
+    }
+
+    public static function fromContents(string $contents, string $workDir, string $label = 'resource'): self
+    {
+        $resource = new self($workDir, $label);
+        $resource->contents = $contents;
+        return $resource;
+    }
+
+    public static function fromPath(string $path, string $workDir, string $label = 'resource'): self
+    {
+        $resource = new self($workDir, $label);
+        $resource->path = $path;
+        return $resource;
+    }
+
+    public function label(): string
+    {
+        return $this->label;
+    }
+
+    /**
+     * Return the resource contents as a string, reading the backing file if the
+     * resource was provided as a path.
+     */
+    public function contents(): string
+    {
+        if ($this->contents !== null) {
+            return $this->contents;
+        }
+        if ($this->path !== null) {
+            $data = file_get_contents($this->path);
+            if ($data === false) {
+                throw new BlueprintException(sprintf('Unable to read resource "%s".', $this->label));
+            }
+            return $data;
+        }
+        throw new BlueprintException(sprintf('Resource "%s" has no contents.', $this->label));
+    }
+
+    /**
+     * Return a filesystem path to a file holding the resource bytes, writing a
+     * temporary file when the resource only exists in memory.
+     */
+    public function path(): string
+    {
+        if ($this->path !== null) {
+            return $this->path;
+        }
+        if ($this->contents !== null) {
+            $tmp = $this->workDir . '/' . 'res_' . substr(sha1($this->label . $this->contents), 0, 16) . '.bin';
+            if (file_put_contents($tmp, $this->contents) === false) {
+                throw new BlueprintException(sprintf('Unable to materialise resource "%s".', $this->label));
+            }
+            $this->path = $tmp;
+            return $this->path;
+        }
+        throw new BlueprintException(sprintf('Resource "%s" has no path.', $this->label));
+    }
+}

--- a/rootfs/usr/local/lib/moodle-blueprint/ResourceResolver.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/ResourceResolver.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace MoodleBlueprint;
+
+/**
+ * Resolves blueprint resource descriptors into concrete bytes.
+ *
+ * Supported descriptor shapes (Moodle Playground style plus the WordPress
+ * Playground `resource` discriminator where it maps cleanly):
+ *
+ *   { "url": "https://..." }                         { "resource": "url", "url": "..." }
+ *   { "base64": "..." }                              { "resource": "base64", "base64": "..." }
+ *   { "data-url": "data:...;base64,..." }
+ *   { "literal": "text" }                            { "resource": "literal", "contents": "..." }
+ *   { "bundled": "plugins/x.zip" }                   { "resource": "bundled", "path": "/plugins/x.zip" }
+ *
+ * Resolved resources are cached for the duration of a single run so a resource
+ * referenced by several steps is only fetched/decoded once.
+ */
+class ResourceResolver
+{
+    /** @var SecurityPolicy */
+    private $policy;
+
+    /** @var string Directory used to materialise temporary files. */
+    private $workDir;
+
+    /** @var string|null Root of the extracted bundle, when one is in use. */
+    private $bundleRoot;
+
+    /** @var Logger */
+    private $logger;
+
+    /** @var array<string,ResolvedResource> */
+    private $cache = [];
+
+    /** @var array<string,mixed> Named resources declared at the blueprint top level. */
+    private $named = [];
+
+    public function __construct(SecurityPolicy $policy, string $workDir, Logger $logger, ?string $bundleRoot = null)
+    {
+        $this->policy = $policy;
+        $this->workDir = $workDir;
+        $this->logger = $logger;
+        $this->bundleRoot = $bundleRoot !== null ? rtrim($bundleRoot, '/') : null;
+    }
+
+    /**
+     * Register the blueprint's top-level `resources` map so steps can use the
+     * "@name" reference syntax.
+     *
+     * @param array<string,mixed> $named
+     */
+    public function setNamedResources(array $named): void
+    {
+        $this->named = $named;
+    }
+
+    /**
+     * Resolve a resource reference as used inside steps. Accepts either:
+     *   - "@name"  -> a named resource declared in the top-level `resources` map
+     *   - an inline descriptor array, e.g. {"url": "..."} or {"bundled": "..."}
+     *
+     * @param mixed $ref
+     */
+    public function resolveReference($ref): ResolvedResource
+    {
+        if (is_string($ref)) {
+            if ($ref === '' || $ref[0] !== '@') {
+                throw new BlueprintException(sprintf('Invalid resource reference "%s" (expected "@name" or a descriptor object).', $ref));
+            }
+            $name = substr($ref, 1);
+            if (!isset($this->named[$name]) || !is_array($this->named[$name])) {
+                throw new BlueprintException(sprintf('Unknown resource reference "@%s".', $name));
+            }
+            return $this->resolve($this->named[$name]);
+        }
+        if (is_array($ref)) {
+            return $this->resolve($ref);
+        }
+        throw new BlueprintException('Resource reference must be a "@name" string or a descriptor object.');
+    }
+
+    /**
+     * Resolve a descriptor (array) into a ResolvedResource.
+     *
+     * @param array<string,mixed> $descriptor
+     */
+    public function resolve(array $descriptor): ResolvedResource
+    {
+        $cacheKey = md5(json_encode($descriptor));
+        if (isset($this->cache[$cacheKey])) {
+            return $this->cache[$cacheKey];
+        }
+
+        $kind = $this->detectKind($descriptor);
+        switch ($kind) {
+            case 'url':
+                $resource = $this->resolveUrl($descriptor);
+                break;
+            case 'base64':
+                $resource = $this->resolveBase64($descriptor);
+                break;
+            case 'data-url':
+                $resource = $this->resolveDataUrl($descriptor);
+                break;
+            case 'literal':
+                $resource = $this->resolveLiteral($descriptor);
+                break;
+            case 'bundled':
+                $resource = $this->resolveBundled($descriptor);
+                break;
+            case 'vfs':
+                throw new BlueprintException('The "vfs" resource type is browser-runtime specific and is not supported by the Docker runtime.');
+            default:
+                throw new BlueprintException(sprintf(
+                    'Unsupported resource descriptor: %s',
+                    json_encode(Logger::redact($descriptor))
+                ));
+        }
+
+        $this->cache[$cacheKey] = $resource;
+        return $resource;
+    }
+
+    /**
+     * @param array<string,mixed> $descriptor
+     */
+    private function detectKind(array $descriptor): string
+    {
+        if (isset($descriptor['resource']) && is_string($descriptor['resource'])) {
+            $r = strtolower($descriptor['resource']);
+            // Normalise a couple of WordPress Playground aliases.
+            if ($r === 'literal' && !isset($descriptor['literal'])) {
+                return 'literal';
+            }
+            return $r;
+        }
+
+        foreach (['url', 'base64', 'literal', 'bundled'] as $key) {
+            if (array_key_exists($key, $descriptor)) {
+                return $key;
+            }
+        }
+        foreach (['data-url', 'dataUrl', 'data_url'] as $key) {
+            if (array_key_exists($key, $descriptor)) {
+                return 'data-url';
+            }
+        }
+        return 'unknown';
+    }
+
+    /**
+     * @param array<string,mixed> $descriptor
+     */
+    private function resolveUrl(array $descriptor): ResolvedResource
+    {
+        $url = (string) ($descriptor['url'] ?? '');
+        if ($url === '') {
+            throw new BlueprintException('URL resource is missing the "url" field.');
+        }
+        $this->policy->assertRemoteAllowed($url);
+        $this->logger->info('Downloading resource: ' . $url);
+        $contents = Http::download($url, $this->policy->maxResourceSize(), $this->logger, $this->workDir);
+        return ResolvedResource::fromContents($contents, $this->workDir, 'url:' . basename(parse_url($url, PHP_URL_PATH) ?: 'download'));
+    }
+
+    /**
+     * @param array<string,mixed> $descriptor
+     */
+    private function resolveBase64(array $descriptor): ResolvedResource
+    {
+        $encoded = (string) ($descriptor['base64'] ?? '');
+        $decoded = base64_decode($encoded, true);
+        if ($decoded === false) {
+            throw new BlueprintException('Invalid base64 resource content.');
+        }
+        $this->policy->assertWithinSizeLimit(strlen($decoded), 'base64 resource');
+        return ResolvedResource::fromContents($decoded, $this->workDir, 'base64');
+    }
+
+    /**
+     * @param array<string,mixed> $descriptor
+     */
+    private function resolveDataUrl(array $descriptor): ResolvedResource
+    {
+        $value = (string) ($descriptor['data-url'] ?? $descriptor['dataUrl'] ?? $descriptor['data_url'] ?? '');
+        if (strncmp($value, 'data:', 5) !== 0) {
+            throw new BlueprintException('Invalid data URL: must start with "data:".');
+        }
+        $comma = strpos($value, ',');
+        if ($comma === false) {
+            throw new BlueprintException('Invalid data URL: missing comma separator.');
+        }
+        $meta = substr($value, 5, $comma - 5);
+        $payload = substr($value, $comma + 1);
+
+        if (stripos($meta, ';base64') !== false) {
+            $decoded = base64_decode($payload, true);
+            if ($decoded === false) {
+                throw new BlueprintException('Invalid base64 payload in data URL.');
+            }
+        } else {
+            $decoded = rawurldecode($payload);
+        }
+
+        $this->policy->assertWithinSizeLimit(strlen($decoded), 'data URL resource');
+        return ResolvedResource::fromContents($decoded, $this->workDir, 'data-url');
+    }
+
+    /**
+     * @param array<string,mixed> $descriptor
+     */
+    private function resolveLiteral(array $descriptor): ResolvedResource
+    {
+        if (array_key_exists('literal', $descriptor)) {
+            $value = $descriptor['literal'];
+        } elseif (array_key_exists('contents', $descriptor)) {
+            $value = $descriptor['contents'];
+        } else {
+            throw new BlueprintException('Literal resource is missing "literal"/"contents".');
+        }
+
+        if (is_array($value)) {
+            $value = json_encode($value);
+        } else {
+            $value = (string) $value;
+        }
+
+        $this->policy->assertWithinSizeLimit(strlen($value), 'literal resource');
+        return ResolvedResource::fromContents($value, $this->workDir, 'literal');
+    }
+
+    /**
+     * @param array<string,mixed> $descriptor
+     */
+    private function resolveBundled(array $descriptor): ResolvedResource
+    {
+        if ($this->bundleRoot === null) {
+            throw new BlueprintException('Bundled resource referenced but no bundle was provided (set MOODLE_BLUEPRINT_BUNDLE).');
+        }
+
+        $relative = (string) ($descriptor['bundled'] ?? $descriptor['path'] ?? '');
+        if ($relative === '') {
+            throw new BlueprintException('Bundled resource is missing its path.');
+        }
+        // Bundle paths may be written with a leading slash relative to the
+        // bundle root (WordPress Playground style); strip it before joining.
+        $relative = ltrim($relative, '/');
+
+        $resolved = $this->policy->safeJoin($this->bundleRoot, $relative);
+        if (!is_file($resolved)) {
+            throw new BlueprintException(sprintf('Bundled resource "%s" not found inside the bundle.', $relative));
+        }
+        $this->policy->assertWithinSizeLimit(filesize($resolved) ?: 0, 'bundled resource');
+
+        return ResolvedResource::fromPath($resolved, $this->workDir, 'bundled:' . $relative);
+    }
+}

--- a/rootfs/usr/local/lib/moodle-blueprint/ResourceResolver.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/ResourceResolver.php
@@ -171,6 +171,11 @@ class ResourceResolver
     private function resolveBase64(array $descriptor): ResolvedResource
     {
         $encoded = (string) ($descriptor['base64'] ?? '');
+        // Reject using the (cheap) encoded length before allocating the decode:
+        // base64 decodes to ~3/4 of its encoded length.
+        if (intdiv(strlen($encoded), 4) * 3 > $this->policy->maxResourceSize()) {
+            $this->policy->assertWithinSizeLimit(intdiv(strlen($encoded), 4) * 3, 'base64 resource');
+        }
         $decoded = base64_decode($encoded, true);
         if ($decoded === false) {
             throw new BlueprintException('Invalid base64 resource content.');
@@ -194,6 +199,11 @@ class ResourceResolver
         }
         $meta = substr($value, 5, $comma - 5);
         $payload = substr($value, $comma + 1);
+
+        // Pre-check on the encoded payload length before decoding. Both base64
+        // (~3/4) and percent-decoding only shrink or keep the payload size, so
+        // the encoded length is a safe upper bound.
+        $this->policy->assertWithinSizeLimit(strlen($payload), 'data URL resource');
 
         if (stripos($meta, ';base64') !== false) {
             $decoded = base64_decode($payload, true);

--- a/rootfs/usr/local/lib/moodle-blueprint/RunContext.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/RunContext.php
@@ -107,7 +107,12 @@ class RunContext
             throw new BlueprintException(sprintf('Moodle CLI script not found: %s', $path));
         }
 
-        $cmd = escapeshellarg(PHP_BINARY) . ' -d max_input_vars=10000 ' . escapeshellarg($path);
+        // Prefer the image's /usr/local/bin/php wrapper, which applies the
+        // operator-configurable ini tuning (memory_limit, post_max_size, …).
+        // Plugin upgrades run via this path can be memory-hungry, so honouring
+        // those settings matters. Fall back to PHP_BINARY off-container.
+        $php = is_executable('/usr/local/bin/php') ? '/usr/local/bin/php' : (PHP_BINARY ?: 'php');
+        $cmd = escapeshellarg($php) . ' -d max_input_vars=10000 ' . escapeshellarg($path);
         foreach ($args as $arg) {
             $cmd .= ' ' . escapeshellarg($arg);
         }

--- a/rootfs/usr/local/lib/moodle-blueprint/RunContext.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/RunContext.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace MoodleBlueprint;
+
+/**
+ * Shared services and configuration handed to every step handler.
+ *
+ * Keeps the step classes free of global lookups: they read everything they
+ * need (logger, policy, resolver, paths, force flag) from this context.
+ */
+class RunContext
+{
+    /** @var Logger */
+    private $logger;
+
+    /** @var SecurityPolicy */
+    private $policy;
+
+    /** @var ResourceResolver */
+    private $resolver;
+
+    /** @var Blueprint */
+    private $blueprint;
+
+    /** @var string Absolute Moodle code root (e.g. /var/www/html). */
+    private $moodleRoot;
+
+    /** @var string Absolute Moodle data root (e.g. /var/www/moodledata). */
+    private $dataRoot;
+
+    /** @var string Working/temporary directory for this run. */
+    private $workDir;
+
+    /** @var bool Whether MOODLE_BLUEPRINT_FORCE is enabled. */
+    private $force;
+
+    public function __construct(
+        Logger $logger,
+        SecurityPolicy $policy,
+        ResourceResolver $resolver,
+        Blueprint $blueprint,
+        string $moodleRoot,
+        string $dataRoot,
+        string $workDir,
+        bool $force
+    ) {
+        $this->logger = $logger;
+        $this->policy = $policy;
+        $this->resolver = $resolver;
+        $this->blueprint = $blueprint;
+        $this->moodleRoot = rtrim($moodleRoot, '/');
+        $this->dataRoot = rtrim($dataRoot, '/');
+        $this->workDir = rtrim($workDir, '/');
+        $this->force = $force;
+    }
+
+    public function logger(): Logger
+    {
+        return $this->logger;
+    }
+
+    public function policy(): SecurityPolicy
+    {
+        return $this->policy;
+    }
+
+    public function resolver(): ResourceResolver
+    {
+        return $this->resolver;
+    }
+
+    public function blueprint(): Blueprint
+    {
+        return $this->blueprint;
+    }
+
+    public function moodleRoot(): string
+    {
+        return $this->moodleRoot;
+    }
+
+    public function dataRoot(): string
+    {
+        return $this->dataRoot;
+    }
+
+    public function workDir(): string
+    {
+        return $this->workDir;
+    }
+
+    public function force(): bool
+    {
+        return $this->force;
+    }
+
+    /**
+     * Run a Moodle CLI script (under <moodleRoot>/admin/cli) with safely
+     * escaped arguments. Returns captured stdout/stderr; throws on failure.
+     *
+     * @param array<int,string> $args e.g. ['--name=debug', '--set=32767']
+     */
+    public function runMoodleCli(string $script, array $args = []): string
+    {
+        $path = $this->moodleRoot . '/admin/cli/' . $script;
+        if (!is_file($path)) {
+            throw new BlueprintException(sprintf('Moodle CLI script not found: %s', $path));
+        }
+
+        $cmd = escapeshellarg(PHP_BINARY) . ' -d max_input_vars=10000 ' . escapeshellarg($path);
+        foreach ($args as $arg) {
+            $cmd .= ' ' . escapeshellarg($arg);
+        }
+        $cmd .= ' 2>&1';
+
+        exec($cmd, $output, $status);
+        $text = implode("\n", $output);
+        if ($status !== 0) {
+            throw new BlueprintException(sprintf('Moodle CLI "%s" failed (exit %d): %s', $script, $status, $text));
+        }
+        return $text;
+    }
+}

--- a/rootfs/usr/local/lib/moodle-blueprint/SecurityPolicy.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/SecurityPolicy.php
@@ -59,6 +59,19 @@ class SecurityPolicy
     }
 
     /**
+     * Hard cap on the total number of DECOMPRESSED bytes written while
+     * extracting an archive.
+     *
+     * Archives legitimately expand to several times their packed size, so this
+     * is generously larger than the per-resource limit, while still stopping
+     * zip bombs that inflate to many gigabytes.
+     */
+    public function maxArchiveSize(): int
+    {
+        return $this->maxResourceSize * 20;
+    }
+
+    /**
      * Parse a human size string such as "50M", "10k", "1G" or a plain byte
      * count into an integer number of bytes.
      */

--- a/rootfs/usr/local/lib/moodle-blueprint/SecurityPolicy.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/SecurityPolicy.php
@@ -1,0 +1,241 @@
+<?php
+
+namespace MoodleBlueprint;
+
+/**
+ * Central security policy for blueprint execution.
+ *
+ * All size limits, remote-resource toggles, unsafe-step toggles and path
+ * containment checks live here so the rest of the runner can stay declarative
+ * and the safe defaults are enforced in a single, auditable place.
+ */
+class SecurityPolicy
+{
+    /** @var bool Whether `url` resources may be downloaded. */
+    private $allowRemoteResources;
+
+    /** @var bool Whether unsafe steps (arbitrary code/file ops) may run. */
+    private $allowUnsafeSteps;
+
+    /** @var int Maximum size in bytes for any resolved/downloaded resource. */
+    private $maxResourceSize;
+
+    /**
+     * Absolute directories under which the runner is allowed to write Moodle
+     * files (plugin installs, etc.). Anything outside is rejected.
+     *
+     * @var string[]
+     */
+    private $allowedMoodlePaths;
+
+    /**
+     * @param string[] $allowedMoodlePaths
+     */
+    public function __construct(
+        bool $allowRemoteResources = true,
+        bool $allowUnsafeSteps = false,
+        int $maxResourceSize = 52428800,
+        array $allowedMoodlePaths = ['/var/www/html']
+    ) {
+        $this->allowRemoteResources = $allowRemoteResources;
+        $this->allowUnsafeSteps = $allowUnsafeSteps;
+        $this->maxResourceSize = $maxResourceSize;
+        $this->allowedMoodlePaths = $allowedMoodlePaths;
+    }
+
+    public function allowsRemoteResources(): bool
+    {
+        return $this->allowRemoteResources;
+    }
+
+    public function allowsUnsafeSteps(): bool
+    {
+        return $this->allowUnsafeSteps;
+    }
+
+    public function maxResourceSize(): int
+    {
+        return $this->maxResourceSize;
+    }
+
+    /**
+     * Parse a human size string such as "50M", "10k", "1G" or a plain byte
+     * count into an integer number of bytes.
+     */
+    public static function parseSize(string $size): int
+    {
+        $size = trim($size);
+        if ($size === '') {
+            throw new BlueprintException('Empty size value.');
+        }
+
+        if (!preg_match('/^([0-9]+(?:\.[0-9]+)?)\s*([kKmMgG]?)[bB]?$/', $size, $m)) {
+            throw new BlueprintException(sprintf('Invalid size value "%s". Use bytes or a K/M/G suffix.', $size));
+        }
+
+        $value = (float) $m[1];
+        switch (strtolower($m[2])) {
+            case 'g':
+                $value *= 1024 * 1024 * 1024;
+                break;
+            case 'm':
+                $value *= 1024 * 1024;
+                break;
+            case 'k':
+                $value *= 1024;
+                break;
+        }
+
+        return (int) $value;
+    }
+
+    /**
+     * Throw unless remote resources are permitted.
+     */
+    public function assertRemoteAllowed(string $url): void
+    {
+        if (!$this->allowRemoteResources) {
+            throw new BlueprintException(sprintf(
+                'Remote resource "%s" rejected: set MOODLE_BLUEPRINT_ALLOW_REMOTE_RESOURCES=true to allow URL resources.',
+                $url
+            ));
+        }
+
+        $scheme = strtolower((string) parse_url($url, PHP_URL_SCHEME));
+        if ($scheme !== 'http' && $scheme !== 'https') {
+            throw new BlueprintException(sprintf('Unsupported URL scheme "%s"; only http/https are allowed.', $scheme));
+        }
+    }
+
+    /**
+     * Throw unless a number of bytes is within the configured maximum.
+     */
+    public function assertWithinSizeLimit(int $bytes, string $what = 'resource'): void
+    {
+        if ($bytes > $this->maxResourceSize) {
+            throw new BlueprintException(sprintf(
+                '%s is %d bytes, exceeding the %d byte limit (MOODLE_BLUEPRINT_MAX_RESOURCE_SIZE).',
+                ucfirst($what),
+                $bytes,
+                $this->maxResourceSize
+            ));
+        }
+    }
+
+    /**
+     * Lexically normalise a path, collapsing "." and ".." segments WITHOUT
+     * touching the filesystem. The result is always absolute when the input is.
+     */
+    public static function normalizePath(string $path): string
+    {
+        $isAbsolute = isset($path[0]) && $path[0] === '/';
+        $parts = explode('/', $path);
+        $stack = [];
+
+        foreach ($parts as $part) {
+            if ($part === '' || $part === '.') {
+                continue;
+            }
+            if ($part === '..') {
+                if ($stack && end($stack) !== '..') {
+                    array_pop($stack);
+                } elseif (!$isAbsolute) {
+                    $stack[] = '..';
+                }
+                continue;
+            }
+            $stack[] = $part;
+        }
+
+        $normalized = implode('/', $stack);
+        return $isAbsolute ? '/' . $normalized : $normalized;
+    }
+
+    /**
+     * Safely join a relative path to a base directory and guarantee the result
+     * stays inside that base. Rejects absolute paths and "../" escapes.
+     *
+     * @return string Absolute, normalised path inside $base.
+     */
+    public function safeJoin(string $base, string $relative): string
+    {
+        if (isset($relative[0]) && $relative[0] === '/') {
+            throw new BlueprintException(sprintf('Absolute resource path "%s" is not allowed.', $relative));
+        }
+        if (strpos($relative, "\0") !== false) {
+            throw new BlueprintException('Null byte in resource path is not allowed.');
+        }
+
+        $base = rtrim(self::normalizePath($base), '/');
+        $candidate = self::normalizePath($base . '/' . $relative);
+
+        $this->assertWithinDirectory($base, $candidate);
+        return $candidate;
+    }
+
+    /**
+     * Throw unless $candidate is contained within $base.
+     *
+     * Both arguments are normalised lexically; when the candidate exists on
+     * disk its realpath is also checked to defeat symlink escapes.
+     */
+    public function assertWithinDirectory(string $base, string $candidate): void
+    {
+        $base = rtrim(self::normalizePath($base), '/');
+        $candidate = self::normalizePath($candidate);
+
+        if ($candidate !== $base && strncmp($candidate . '/', $base . '/', strlen($base) + 1) !== 0) {
+            throw new BlueprintException(sprintf('Path "%s" escapes the allowed directory "%s".', $candidate, $base));
+        }
+
+        // If the target already exists, resolve symlinks and re-check so that a
+        // symlink inside the bundle cannot point outside it.
+        $realBase = realpath($base);
+        $realCandidate = realpath($candidate);
+        if ($realBase !== false && $realCandidate !== false) {
+            if ($realCandidate !== $realBase && strncmp($realCandidate . '/', $realBase . '/', strlen($realBase) + 1) !== 0) {
+                throw new BlueprintException(sprintf('Path "%s" resolves outside the allowed directory.', $candidate));
+            }
+        }
+    }
+
+    /**
+     * Throw unless $path lives under one of the allowlisted Moodle directories.
+     * Used before the runner writes plugin files into the codebase.
+     */
+    public function assertAllowedMoodlePath(string $path): void
+    {
+        $normalized = self::normalizePath($path);
+        foreach ($this->allowedMoodlePaths as $allowed) {
+            $allowed = rtrim(self::normalizePath($allowed), '/');
+            if ($normalized === $allowed || strncmp($normalized . '/', $allowed . '/', strlen($allowed) + 1) === 0) {
+                return;
+            }
+        }
+        throw new BlueprintException(sprintf(
+            'Refusing to write outside allowlisted Moodle directories: "%s".',
+            $path
+        ));
+    }
+
+    /**
+     * Validate a ZIP entry name before it is used as a destination path.
+     * Rejects absolute paths, parent-directory traversal and null bytes.
+     */
+    public function assertSafeArchiveEntry(string $name): void
+    {
+        if ($name === '') {
+            throw new BlueprintException('Empty archive entry name.');
+        }
+        if (isset($name[0]) && $name[0] === '/') {
+            throw new BlueprintException(sprintf('Archive entry "%s" uses an absolute path (possible ZIP slip).', $name));
+        }
+        if (strpos($name, "\0") !== false) {
+            throw new BlueprintException('Archive entry contains a null byte.');
+        }
+        // Drive-letter / backslash style paths are never valid here either.
+        if (preg_match('#(^|/)\.\.(/|$)#', $name) || strpos($name, '\\') !== false) {
+            throw new BlueprintException(sprintf('Archive entry "%s" attempts directory traversal (possible ZIP slip).', $name));
+        }
+    }
+}

--- a/rootfs/usr/local/lib/moodle-blueprint/StepRegistry.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/StepRegistry.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace MoodleBlueprint;
+
+/**
+ * Maps blueprint step names to their handler classes and classifies every
+ * other Moodle Playground step so the runner can react predictably:
+ *
+ *   - IMPLEMENTED : run the handler.
+ *   - NO-OP       : intentionally skipped in Docker (e.g. installMoodle/login),
+ *                   logged loudly rather than silently ignored.
+ *   - PLANNED     : a recognised Moodle Playground step not yet implemented by
+ *                   the Docker runtime — fails clearly.
+ *   - UNSAFE      : arbitrary code/file operations, disabled by default.
+ *   - UNKNOWN     : not a recognised step — fails clearly.
+ */
+class StepRegistry
+{
+    public const IMPLEMENTED = 'implemented';
+    public const NOOP = 'noop';
+    public const PLANNED = 'planned';
+    public const UNSAFE = 'unsafe';
+    public const UNKNOWN = 'unknown';
+
+    /** @var array<string,string> step name => handler class */
+    private const HANDLERS = [
+        'setConfig'           => Steps\SetConfigStep::class,
+        'setConfigs'          => Steps\SetConfigsStep::class,
+        'setAdminAccount'     => Steps\SetAdminAccountStep::class,
+        'installMoodlePlugin' => Steps\InstallMoodlePluginStep::class,
+        'installTheme'        => Steps\InstallThemeStep::class,
+        'setTheme'            => Steps\SetThemeStep::class,
+        'createCategory'      => Steps\CreateCategoryStep::class,
+        'createCourse'        => Steps\CreateCourseStep::class,
+        'createUser'          => Steps\CreateUserStep::class,
+        'createUsers'         => Steps\CreateUsersStep::class,
+        'enrolUser'           => Steps\EnrolUserStep::class,
+    ];
+
+    /**
+     * Steps that have no meaning in the Docker runtime because the container
+     * already handles them. Skipped with an explanatory log line.
+     *
+     * @var string[]
+     */
+    private const NOOP_STEPS = [
+        'installMoodle', // Moodle is installed/upgraded by the container startup.
+        'login',         // Browser-only auto-login; not applicable server-side.
+    ];
+
+    /**
+     * Steps that perform arbitrary code or unrestricted file operations.
+     * Disabled by default and not implemented in this version.
+     *
+     * @var string[]
+     */
+    private const UNSAFE_STEPS = [
+        'runPhpCode', 'runPhpScript', 'runCli', 'request',
+        'writeFile', 'writeFiles', 'unzip', 'mkdir', 'rmdir',
+        'copyFile', 'moveFile',
+    ];
+
+    /**
+     * Recognised Moodle Playground steps not yet implemented by the Docker
+     * runtime. Listed so the runner can emit a "planned" message instead of an
+     * "unknown step" error.
+     *
+     * @var string[]
+     */
+    private const PLANNED_STEPS = [
+        'setConfigFile', 'setConfigFiles', 'setLandingPage',
+        'createCategories', 'createCourses',
+        'createSection', 'createSections',
+        'enrolUsers', 'restoreCourse', 'addModule', 'installLanguagePack',
+        'createRole', 'createRoles', 'importRolePreset', 'importRoles',
+        'createScale', 'createScales', 'createCohort', 'createCohorts',
+    ];
+
+    /**
+     * Classify a step name into one of the class constants above.
+     */
+    public function classify(string $name): string
+    {
+        if (isset(self::HANDLERS[$name])) {
+            return self::IMPLEMENTED;
+        }
+        if (in_array($name, self::NOOP_STEPS, true)) {
+            return self::NOOP;
+        }
+        if (in_array($name, self::UNSAFE_STEPS, true)) {
+            return self::UNSAFE;
+        }
+        if (in_array($name, self::PLANNED_STEPS, true)) {
+            return self::PLANNED;
+        }
+        return self::UNKNOWN;
+    }
+
+    /**
+     * Instantiate the handler for an implemented step.
+     */
+    public function handler(string $name): Steps\StepInterface
+    {
+        if (!isset(self::HANDLERS[$name])) {
+            throw new BlueprintException(sprintf('No handler registered for step "%s".', $name));
+        }
+        $class = self::HANDLERS[$name];
+        return new $class();
+    }
+
+    /**
+     * @return string[] Names of implemented steps.
+     */
+    public function implementedSteps(): array
+    {
+        return array_keys(self::HANDLERS);
+    }
+}

--- a/rootfs/usr/local/lib/moodle-blueprint/Steps/AbstractStep.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/Steps/AbstractStep.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace MoodleBlueprint\Steps;
+
+use MoodleBlueprint\BlueprintException;
+use MoodleBlueprint\ResolvedResource;
+use MoodleBlueprint\RunContext;
+
+/**
+ * Base class with shared argument-reading and helper logic for step handlers.
+ */
+abstract class AbstractStep implements StepInterface
+{
+    /**
+     * Require a non-empty string field.
+     *
+     * @param array<string,mixed> $config
+     */
+    protected function requireString(array $config, string $key): string
+    {
+        if (!isset($config[$key]) || !is_scalar($config[$key]) || (string) $config[$key] === '') {
+            throw new BlueprintException(sprintf('Missing required "%s" field.', $key));
+        }
+        return (string) $config[$key];
+    }
+
+    /**
+     * Read an optional string field with a default.
+     *
+     * @param array<string,mixed> $config
+     */
+    protected function optString(array $config, string $key, string $default = ''): string
+    {
+        if (!isset($config[$key]) || !is_scalar($config[$key])) {
+            return $default;
+        }
+        return (string) $config[$key];
+    }
+
+    /**
+     * Read an optional boolean field with a default.
+     *
+     * @param array<string,mixed> $config
+     */
+    protected function optBool(array $config, string $key, bool $default): bool
+    {
+        if (!array_key_exists($key, $config)) {
+            return $default;
+        }
+        return filter_var($config[$key], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? $default;
+    }
+
+    /**
+     * Convert a blueprint value into a string Moodle config accepts.
+     *
+     * @param mixed $value
+     */
+    protected function coerceConfigValue($value): string
+    {
+        if (is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+        if ($value === null) {
+            return '';
+        }
+        if (is_array($value)) {
+            throw new BlueprintException('Config values must be scalars, not arrays.');
+        }
+        return (string) $value;
+    }
+
+    /**
+     * Resolve a plugin/theme ZIP source from common step shapes:
+     *   - "source"  : "@ref" or an inline descriptor object
+     *   - "url"     : remote ZIP URL
+     *   - "zipUrl"  : remote ZIP URL (Moodle Playground alias)
+     *   - "bundled" : path inside the bundle
+     *
+     * @param array<string,mixed> $config
+     */
+    protected function resolveZipSource(RunContext $context, array $config): ResolvedResource
+    {
+        if (isset($config['source'])) {
+            return $context->resolver()->resolveReference($config['source']);
+        }
+        foreach (['zipUrl', 'url'] as $key) {
+            if (isset($config[$key]) && is_string($config[$key]) && $config[$key] !== '') {
+                return $context->resolver()->resolve(['url' => $config[$key]]);
+            }
+        }
+        if (isset($config['bundled']) && is_string($config['bundled'])) {
+            return $context->resolver()->resolve(['bundled' => $config['bundled']]);
+        }
+        throw new BlueprintException('No plugin source provided (expected "source", "url", "zipUrl" or "bundled").');
+    }
+
+    /**
+     * Ensure Moodle has been bootstrapped before using its PHP API.
+     */
+    protected function requireMoodle(): void
+    {
+        if (!isset($GLOBALS['CFG']) || !isset($GLOBALS['DB'])) {
+            throw new BlueprintException('This step requires a bootstrapped Moodle environment.');
+        }
+    }
+}

--- a/rootfs/usr/local/lib/moodle-blueprint/Steps/CreateCategoryStep.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/Steps/CreateCategoryStep.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace MoodleBlueprint\Steps;
+
+use MoodleBlueprint\BlueprintException;
+use MoodleBlueprint\RunContext;
+
+/**
+ * createCategory — create a course category (idempotent).
+ *
+ * Input:
+ *   { "step": "createCategory", "name": "Demo",
+ *     "idnumber": "demo", "parent": "Parent category", "description": "..." }
+ *
+ * Idempotent by idnumber when provided, otherwise by name under the same
+ * parent. Returns/logs the resulting category id.
+ */
+class CreateCategoryStep extends AbstractStep
+{
+    public function run(RunContext $context, array $config, int $index): void
+    {
+        $this->requireMoodle();
+        $id = self::createOrGet(
+            $context,
+            $this->requireString($config, 'name'),
+            $this->optString($config, 'idnumber'),
+            $this->optString($config, 'parent'),
+            $this->optString($config, 'description')
+        );
+        $context->logger()->info(sprintf('Category "%s" ready (id=%d).', $config['name'], $id));
+    }
+
+    /**
+     * Create the category if missing and return its id.
+     */
+    public static function createOrGet(
+        RunContext $context,
+        string $name,
+        string $idnumber = '',
+        string $parent = '',
+        string $description = ''
+    ): int {
+        global $DB;
+
+        $parentid = 0;
+        if ($parent !== '') {
+            $parentid = self::resolveCategoryId($parent);
+            if ($parentid === 0) {
+                throw new BlueprintException(sprintf('Parent category "%s" not found.', $parent));
+            }
+        }
+
+        // Idempotency check.
+        if ($idnumber !== '') {
+            $existing = $DB->get_record('course_categories', ['idnumber' => $idnumber]);
+        } else {
+            $existing = $DB->get_record('course_categories', ['name' => $name, 'parent' => $parentid]);
+        }
+        if ($existing) {
+            return (int) $existing->id;
+        }
+
+        $data = ['name' => $name, 'parent' => $parentid];
+        if ($idnumber !== '') {
+            $data['idnumber'] = $idnumber;
+        }
+        if ($description !== '') {
+            $data['description'] = $description;
+        }
+
+        $category = \core_course_category::create((object) $data);
+        return (int) $category->id;
+    }
+
+    /**
+     * Resolve a category by idnumber first, then by name. Returns 0 if none.
+     */
+    public static function resolveCategoryId(string $reference): int
+    {
+        global $DB;
+        $record = $DB->get_record('course_categories', ['idnumber' => $reference]);
+        if (!$record) {
+            $record = $DB->get_record('course_categories', ['name' => $reference], '*', IGNORE_MULTIPLE);
+        }
+        return $record ? (int) $record->id : 0;
+    }
+}

--- a/rootfs/usr/local/lib/moodle-blueprint/Steps/CreateCourseStep.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/Steps/CreateCourseStep.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace MoodleBlueprint\Steps;
+
+use MoodleBlueprint\BlueprintException;
+use MoodleBlueprint\RunContext;
+
+/**
+ * createCourse — create a course (idempotent by shortname).
+ *
+ * Input:
+ *   { "step": "createCourse", "fullname": "Demo course",
+ *     "shortname": "DEMO101", "category": "Demo",
+ *     "summary": "...", "format": "topics", "numsections": 5 }
+ *
+ * If a course with the same shortname exists, its basic fields are updated
+ * instead of creating a duplicate. The category is resolved by idnumber or
+ * name; an unknown explicit category is an error.
+ */
+class CreateCourseStep extends AbstractStep
+{
+    public function run(RunContext $context, array $config, int $index): void
+    {
+        $this->requireMoodle();
+        global $DB, $CFG;
+        require_once($CFG->dirroot . '/course/lib.php');
+
+        $fullname = $this->requireString($config, 'fullname');
+        $shortname = $this->requireString($config, 'shortname');
+        $summary = $this->optString($config, 'summary');
+        $format = $this->optString($config, 'format');
+
+        $categoryid = $this->resolveCategory($config);
+
+        $existing = $DB->get_record('course', ['shortname' => $shortname]);
+        if ($existing) {
+            $update = (object) ['id' => $existing->id, 'fullname' => $fullname];
+            if ($summary !== '') {
+                $update->summary = $summary;
+            }
+            update_course($update);
+            $context->logger()->info(sprintf('Course "%s" already existed; basic fields updated (id=%d).', $shortname, $existing->id));
+            return;
+        }
+
+        $course = (object) [
+            'fullname' => $fullname,
+            'shortname' => $shortname,
+            'category' => $categoryid,
+            'summary' => $summary,
+            'summaryformat' => FORMAT_HTML,
+        ];
+        if ($format !== '') {
+            $course->format = $format;
+        }
+        if (isset($config['numsections']) && is_numeric($config['numsections'])) {
+            $course->numsections = (int) $config['numsections'];
+        }
+
+        $created = create_course($course);
+        $context->logger()->info(sprintf('Created course "%s" (id=%d).', $shortname, $created->id));
+    }
+
+    /**
+     * Resolve the destination category id. Defaults to the first available
+     * category when none is specified.
+     *
+     * @param array<string,mixed> $config
+     */
+    private function resolveCategory(array $config): int
+    {
+        global $DB;
+        $category = $this->optString($config, 'category');
+        if ($category === '') {
+            $first = $DB->get_records('course_categories', null, 'sortorder ASC', 'id', 0, 1);
+            if ($first) {
+                return (int) reset($first)->id;
+            }
+            throw new BlueprintException('No course category available to create the course in.');
+        }
+        $id = CreateCategoryStep::resolveCategoryId($category);
+        if ($id === 0) {
+            throw new BlueprintException(sprintf('Category "%s" not found for course.', $category));
+        }
+        return $id;
+    }
+}

--- a/rootfs/usr/local/lib/moodle-blueprint/Steps/CreateUserStep.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/Steps/CreateUserStep.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace MoodleBlueprint\Steps;
+
+use MoodleBlueprint\BlueprintException;
+use MoodleBlueprint\RunContext;
+
+/**
+ * createUser — create a user (idempotent by username).
+ *
+ * Input:
+ *   { "step": "createUser", "username": "student1", "password": "...",
+ *     "email": "student1@example.com", "firstname": "Student", "lastname": "One" }
+ *
+ * If the user exists, basic profile fields are updated; the password is only
+ * changed when one is explicitly provided. Passwords are never logged.
+ */
+class CreateUserStep extends AbstractStep
+{
+    public function run(RunContext $context, array $config, int $index): void
+    {
+        $this->requireMoodle();
+        $id = self::createOrUpdate($context, $config);
+        $context->logger()->info(sprintf('User "%s" ready (id=%d).', $config['username'], $id));
+    }
+
+    /**
+     * Create or update a user from a config array and return its id.
+     *
+     * @param array<string,mixed> $config
+     */
+    public static function createOrUpdate(RunContext $context, array $config): int
+    {
+        global $DB, $CFG;
+        require_once($CFG->dirroot . '/user/lib.php');
+
+        if (!isset($config['username']) || !is_string($config['username']) || $config['username'] === '') {
+            throw new BlueprintException('createUser requires a "username".');
+        }
+        $username = \core_text::strtolower(trim($config['username']));
+        $password = isset($config['password']) && is_scalar($config['password']) ? (string) $config['password'] : '';
+
+        $existing = $DB->get_record('user', ['username' => $username, 'mnethostid' => $CFG->mnet_localhost_id]);
+        if ($existing) {
+            $update = (object) ['id' => $existing->id];
+            foreach (['email', 'firstname', 'lastname'] as $field) {
+                if (isset($config[$field]) && is_scalar($config[$field]) && (string) $config[$field] !== '') {
+                    $update->$field = (string) $config[$field];
+                }
+            }
+            user_update_user($update, false, false);
+            if ($password !== '') {
+                update_internal_user_password($existing, $password);
+            }
+            return (int) $existing->id;
+        }
+
+        $user = (object) [
+            'username' => $username,
+            'auth' => self::stringOr($config, 'auth', 'manual'),
+            'confirmed' => 1,
+            'mnethostid' => $CFG->mnet_localhost_id,
+            'email' => self::stringOr($config, 'email', $username . '@example.com'),
+            'firstname' => self::stringOr($config, 'firstname', $username),
+            'lastname' => self::stringOr($config, 'lastname', 'User'),
+            'lang' => self::stringOr($config, 'lang', $CFG->lang ?? 'en'),
+        ];
+        // A valid local account needs a password; generate one when none is
+        // supplied (never logged) so the account is usable.
+        $user->password = $password !== '' ? $password : self::randomPassword();
+
+        $id = user_create_user($user, true, false);
+        return (int) $id;
+    }
+
+    /**
+     * @param array<string,mixed> $config
+     */
+    private static function stringOr(array $config, string $key, string $default): string
+    {
+        return isset($config[$key]) && is_scalar($config[$key]) && (string) $config[$key] !== ''
+            ? (string) $config[$key]
+            : $default;
+    }
+
+    private static function randomPassword(): string
+    {
+        // Mixed-class password to satisfy default Moodle password policy.
+        return 'Bp!' . bin2hex(random_bytes(8)) . 'A1';
+    }
+}

--- a/rootfs/usr/local/lib/moodle-blueprint/Steps/CreateUsersStep.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/Steps/CreateUsersStep.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace MoodleBlueprint\Steps;
+
+use MoodleBlueprint\BlueprintException;
+use MoodleBlueprint\RunContext;
+
+/**
+ * createUsers — create or update several users.
+ *
+ * Input:
+ *   { "step": "createUsers", "users": [ { "username": "student1", ... } ] }
+ */
+class CreateUsersStep extends AbstractStep
+{
+    public function run(RunContext $context, array $config, int $index): void
+    {
+        $this->requireMoodle();
+        if (!isset($config['users']) || !is_array($config['users'])) {
+            throw new BlueprintException('createUsers requires a "users" array.');
+        }
+
+        foreach ($config['users'] as $i => $user) {
+            if (!is_array($user)) {
+                throw new BlueprintException(sprintf('createUsers entry %d must be an object.', $i));
+            }
+            $id = CreateUserStep::createOrUpdate($context, $user);
+            $context->logger()->info(sprintf('User "%s" ready (id=%d).', $user['username'] ?? '?', $id));
+        }
+    }
+}

--- a/rootfs/usr/local/lib/moodle-blueprint/Steps/EnrolUserStep.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/Steps/EnrolUserStep.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace MoodleBlueprint\Steps;
+
+use MoodleBlueprint\BlueprintException;
+use MoodleBlueprint\RunContext;
+
+/**
+ * enrolUser — enrol a user into a course via manual enrolment (idempotent).
+ *
+ * Input:
+ *   { "step": "enrolUser", "username": "student1",
+ *     "course": "DEMO101", "role": "student" }
+ *
+ * Resolves the user by username, the course by shortname and the role by
+ * shortname, then enrols through the manual enrolment plugin. Re-running does
+ * not create duplicate enrolments.
+ */
+class EnrolUserStep extends AbstractStep
+{
+    public function run(RunContext $context, array $config, int $index): void
+    {
+        $this->requireMoodle();
+        global $DB, $CFG;
+
+        $username = $this->requireString($config, 'username');
+        $courseShortname = $this->requireString($config, 'course');
+        $roleShortname = $this->optString($config, 'role', 'student');
+
+        $user = $DB->get_record('user', ['username' => \core_text::strtolower($username)]);
+        if (!$user) {
+            throw new BlueprintException(sprintf('Cannot enrol: user "%s" not found.', $username));
+        }
+        $course = $DB->get_record('course', ['shortname' => $courseShortname]);
+        if (!$course) {
+            throw new BlueprintException(sprintf('Cannot enrol: course "%s" not found.', $courseShortname));
+        }
+        $role = $DB->get_record('role', ['shortname' => $roleShortname]);
+        if (!$role) {
+            throw new BlueprintException(sprintf('Cannot enrol: role "%s" not found.', $roleShortname));
+        }
+
+        $plugin = enrol_get_plugin('manual');
+        if (!$plugin) {
+            throw new BlueprintException('Manual enrolment plugin is not available.');
+        }
+
+        $instance = $DB->get_record('enrol', ['courseid' => $course->id, 'enrol' => 'manual']);
+        if (!$instance) {
+            $instanceid = $plugin->add_instance($course);
+            $instance = $DB->get_record('enrol', ['id' => $instanceid], '*', MUST_EXIST);
+        }
+
+        // enrol_user is safe to call repeatedly; it updates rather than duplicates.
+        $plugin->enrol_user($instance, $user->id, $role->id);
+
+        $context->logger()->info(sprintf(
+            'Enrolled "%s" into "%s" as "%s".',
+            $username,
+            $courseShortname,
+            $roleShortname
+        ));
+    }
+}

--- a/rootfs/usr/local/lib/moodle-blueprint/Steps/EnrolUserStep.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/Steps/EnrolUserStep.php
@@ -27,7 +27,12 @@ class EnrolUserStep extends AbstractStep
         $courseShortname = $this->requireString($config, 'course');
         $roleShortname = $this->optString($config, 'role', 'student');
 
-        $user = $DB->get_record('user', ['username' => \core_text::strtolower($username)]);
+        // Match CreateUserStep's normalisation (trim + lowercase) and scope by
+        // mnethostid so we resolve the same account createUser provisioned.
+        $user = $DB->get_record('user', [
+            'username' => \core_text::strtolower(trim($username)),
+            'mnethostid' => $CFG->mnet_localhost_id,
+        ]);
         if (!$user) {
             throw new BlueprintException(sprintf('Cannot enrol: user "%s" not found.', $username));
         }

--- a/rootfs/usr/local/lib/moodle-blueprint/Steps/InstallMoodlePluginStep.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/Steps/InstallMoodlePluginStep.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace MoodleBlueprint\Steps;
+
+use MoodleBlueprint\Archive;
+use MoodleBlueprint\BlueprintException;
+use MoodleBlueprint\Frankenstyle;
+use MoodleBlueprint\ResolvedResource;
+use MoodleBlueprint\RunContext;
+
+/**
+ * installMoodlePlugin — install a plugin from a ZIP resource.
+ *
+ * Input shapes:
+ *   { "step": "installMoodlePlugin", "source": "@pluginZip" }
+ *   { "step": "installMoodlePlugin", "zipUrl": "https://.../plugin.zip" }
+ *   { "step": "installMoodlePlugin", "url": "https://.../plugin.zip" }
+ *
+ * The ZIP is validated and extracted safely (ZIP-slip proof), its
+ * version.php is parsed WITHOUT executing it, the frankenstyle component is
+ * mapped to its install directory, and Moodle's CLI upgrade is run. Installs
+ * are idempotent: an already-present plugin of the same version is left alone
+ * unless MOODLE_BLUEPRINT_FORCE is set.
+ */
+class InstallMoodlePluginStep extends AbstractStep
+{
+    public function run(RunContext $context, array $config, int $index): void
+    {
+        $resource = $this->resolveZipSource($context, $config);
+        self::install($context, $resource);
+    }
+
+    /**
+     * Shared install routine used by installMoodlePlugin and installTheme.
+     *
+     * @param string|null $expectedType frankenstyle type to enforce (e.g. "theme").
+     */
+    public static function install(RunContext $context, ResolvedResource $resource, ?string $expectedType = null): void
+    {
+        $logger = $context->logger();
+        $policy = $context->policy();
+
+        $zipPath = $resource->path();
+        if (!Archive::isZip($zipPath)) {
+            throw new BlueprintException(sprintf('Resource "%s" is not a valid ZIP archive.', $resource->label()));
+        }
+
+        $extractDir = $context->workDir() . '/plugin_' . substr(sha1($resource->label() . $zipPath), 0, 12);
+        Archive::extract($policy, $zipPath, $extractDir);
+
+        [$pluginDir, $component, $version] = self::inspectPlugin($extractDir);
+        [$type] = explode('_', $component, 2);
+
+        if ($expectedType !== null && $type !== $expectedType) {
+            throw new BlueprintException(sprintf(
+                'Expected a "%s" plugin but the archive contains "%s".',
+                $expectedType,
+                $component
+            ));
+        }
+
+        $relative = Frankenstyle::relativePath($component);
+        $target = $context->moodleRoot() . '/' . $relative;
+        $policy->assertAllowedMoodlePath($target);
+
+        if (is_dir($target)) {
+            $existingVersion = self::readVersion($target . '/version.php');
+            if (!$context->force() && $existingVersion !== null && $existingVersion === $version) {
+                $logger->info(sprintf('Plugin %s already installed (version %s); skipping.', $component, $version));
+                return;
+            }
+            $logger->info(sprintf('Replacing existing plugin %s at %s.', $component, $relative));
+            self::removeDir($target);
+        }
+
+        $parent = dirname($target);
+        if (!is_dir($parent) && !mkdir($parent, 0775, true) && !is_dir($parent)) {
+            throw new BlueprintException(sprintf('Unable to create plugin directory "%s".', $parent));
+        }
+        if (!rename($pluginDir, $target)) {
+            throw new BlueprintException(sprintf('Unable to move plugin into place at "%s".', $target));
+        }
+
+        // Match the image convention; the container runs as the nobody user, so
+        // chowning to another owner is best-effort.
+        @self::chownRecursive($target, 'nobody', 'nobody');
+
+        $logger->info(sprintf('Installed plugin %s (version %s) into %s.', $component, $version ?? 'unknown', $relative));
+
+        $context->runMoodleCli('upgrade.php', ['--non-interactive', '--allow-unstable']);
+        $logger->info('Moodle upgrade completed after plugin install.');
+    }
+
+    /**
+     * Find the plugin root inside the extracted tree and return
+     * [pluginDir, component, version].
+     *
+     * @return array{0:string,1:string,2:?string}
+     */
+    private static function inspectPlugin(string $root): array
+    {
+        $versionFiles = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS)
+        );
+        foreach ($iterator as $file) {
+            if ($file->getFilename() === 'version.php') {
+                $versionFiles[] = $file->getPathname();
+            }
+        }
+        if ($versionFiles === []) {
+            throw new BlueprintException('No version.php found in the plugin archive.');
+        }
+
+        // Prefer the shallowest version.php that declares a component.
+        usort($versionFiles, static function ($a, $b) {
+            return substr_count($a, '/') <=> substr_count($b, '/');
+        });
+
+        foreach ($versionFiles as $vf) {
+            $component = self::readComponent($vf);
+            if ($component !== null) {
+                return [dirname($vf), $component, self::readVersion($vf)];
+            }
+        }
+        throw new BlueprintException('Could not determine the plugin component from version.php ($plugin->component).');
+    }
+
+    /**
+     * Parse $plugin->component from a version.php without executing it.
+     */
+    private static function readComponent(string $versionFile): ?string
+    {
+        $contents = @file_get_contents($versionFile);
+        if ($contents === false) {
+            return null;
+        }
+        if (preg_match('/\$plugin->component\s*=\s*[\'"]([a-z][a-z0-9_]+)[\'"]\s*;/', $contents, $m)) {
+            return $m[1];
+        }
+        return null;
+    }
+
+    /**
+     * Parse $plugin->version from a version.php without executing it.
+     */
+    private static function readVersion(string $versionFile): ?string
+    {
+        $contents = @file_get_contents($versionFile);
+        if ($contents === false) {
+            return null;
+        }
+        if (preg_match('/\$plugin->version\s*=\s*([0-9]+(?:\.[0-9]+)?)\s*;/', $contents, $m)) {
+            return $m[1];
+        }
+        return null;
+    }
+
+    private static function removeDir(string $dir): void
+    {
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($iterator as $item) {
+            if ($item->isDir()) {
+                @rmdir($item->getPathname());
+            } else {
+                @unlink($item->getPathname());
+            }
+        }
+        @rmdir($dir);
+    }
+
+    private static function chownRecursive(string $path, string $user, string $group): void
+    {
+        @chown($path, $user);
+        @chgrp($path, $group);
+        if (is_dir($path)) {
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS)
+            );
+            foreach ($iterator as $item) {
+                @chown($item->getPathname(), $user);
+                @chgrp($item->getPathname(), $group);
+            }
+        }
+    }
+}

--- a/rootfs/usr/local/lib/moodle-blueprint/Steps/InstallThemeStep.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/Steps/InstallThemeStep.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace MoodleBlueprint\Steps;
+
+use MoodleBlueprint\RunContext;
+
+/**
+ * installTheme — install a theme plugin from a ZIP resource.
+ *
+ * Shares the safe install routine with installMoodlePlugin but enforces that
+ * the archive contains a theme_* component.
+ *
+ *   { "step": "installTheme", "source": "@themeZip" }
+ *   { "step": "installTheme", "url": "https://.../theme.zip" }
+ */
+class InstallThemeStep extends AbstractStep
+{
+    public function run(RunContext $context, array $config, int $index): void
+    {
+        $resource = $this->resolveZipSource($context, $config);
+        InstallMoodlePluginStep::install($context, $resource, 'theme');
+    }
+}

--- a/rootfs/usr/local/lib/moodle-blueprint/Steps/SetAdminAccountStep.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/Steps/SetAdminAccountStep.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace MoodleBlueprint\Steps;
+
+use MoodleBlueprint\BlueprintException;
+use MoodleBlueprint\RunContext;
+
+/**
+ * setAdminAccount — update the primary admin account.
+ *
+ * Input (all fields optional):
+ *   { "step": "setAdminAccount", "username": "admin", "password": "...",
+ *     "email": "admin@example.com", "firstname": "Admin", "lastname": "User" }
+ *
+ * When username, password and email are all provided, the existing
+ * admin/cli/update_admin_user.php helper is reused. Partial updates (and the
+ * optional firstname/lastname fields) go through the Moodle API. The password
+ * is never written to the logs.
+ */
+class SetAdminAccountStep extends AbstractStep
+{
+    public function run(RunContext $context, array $config, int $index): void
+    {
+        $username = $this->optString($config, 'username');
+        $password = $this->optString($config, 'password');
+        $email = $this->optString($config, 'email');
+        $firstname = $this->optString($config, 'firstname');
+        $lastname = $this->optString($config, 'lastname');
+
+        if ($username === '' && $password === '' && $email === '' && $firstname === '' && $lastname === '') {
+            throw new BlueprintException('setAdminAccount requires at least one field to update.');
+        }
+
+        $fullTriple = $username !== '' && $password !== '' && $email !== '';
+        $needsApi = $firstname !== '' || $lastname !== '' || !$fullTriple;
+
+        if (!$needsApi) {
+            // Preferred path: reuse the proven CLI helper for the common case.
+            $context->runMoodleCli('update_admin_user.php', [
+                '--username=' . $username,
+                '--password=' . $password,
+                '--email=' . $email,
+            ]);
+            $context->logger()->info('Admin account updated (username/email/password).');
+            return;
+        }
+
+        $this->updateViaApi($context, $username, $password, $email, $firstname, $lastname);
+    }
+
+    private function updateViaApi(
+        RunContext $context,
+        string $username,
+        string $password,
+        string $email,
+        string $firstname,
+        string $lastname
+    ): void {
+        $this->requireMoodle();
+        global $DB;
+
+        $admin = get_admin();
+        if (!$admin) {
+            throw new BlueprintException('No admin user found to update.');
+        }
+
+        if ($username !== '') {
+            $admin->username = $username;
+        }
+        if ($email !== '') {
+            $admin->email = $email;
+        }
+        if ($firstname !== '') {
+            $admin->firstname = $firstname;
+        }
+        if ($lastname !== '') {
+            $admin->lastname = $lastname;
+        }
+        $DB->update_record('user', $admin);
+
+        if ($password !== '') {
+            update_internal_user_password($admin, $password);
+        }
+
+        $context->logger()->info('Admin account updated via Moodle API.');
+    }
+}

--- a/rootfs/usr/local/lib/moodle-blueprint/Steps/SetAdminAccountStep.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/Steps/SetAdminAccountStep.php
@@ -12,10 +12,10 @@ use MoodleBlueprint\RunContext;
  *   { "step": "setAdminAccount", "username": "admin", "password": "...",
  *     "email": "admin@example.com", "firstname": "Admin", "lastname": "User" }
  *
- * When username, password and email are all provided, the existing
- * admin/cli/update_admin_user.php helper is reused. Partial updates (and the
- * optional firstname/lastname fields) go through the Moodle API. The password
- * is never written to the logs.
+ * Updates go through the Moodle API (the runner is bootstrapped), which keeps
+ * the password out of the process argument vector — unlike shelling out to
+ * admin/cli/update_admin_user.php with --password=. The password is never
+ * written to the logs.
  */
 class SetAdminAccountStep extends AbstractStep
 {
@@ -29,20 +29,6 @@ class SetAdminAccountStep extends AbstractStep
 
         if ($username === '' && $password === '' && $email === '' && $firstname === '' && $lastname === '') {
             throw new BlueprintException('setAdminAccount requires at least one field to update.');
-        }
-
-        $fullTriple = $username !== '' && $password !== '' && $email !== '';
-        $needsApi = $firstname !== '' || $lastname !== '' || !$fullTriple;
-
-        if (!$needsApi) {
-            // Preferred path: reuse the proven CLI helper for the common case.
-            $context->runMoodleCli('update_admin_user.php', [
-                '--username=' . $username,
-                '--password=' . $password,
-                '--email=' . $email,
-            ]);
-            $context->logger()->info('Admin account updated (username/email/password).');
-            return;
         }
 
         $this->updateViaApi($context, $username, $password, $email, $firstname, $lastname);

--- a/rootfs/usr/local/lib/moodle-blueprint/Steps/SetConfigStep.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/Steps/SetConfigStep.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace MoodleBlueprint\Steps;
+
+use MoodleBlueprint\BlueprintException;
+use MoodleBlueprint\RunContext;
+
+/**
+ * setConfig — set a single Moodle configuration value via admin/cli/cfg.php.
+ *
+ * Input:
+ *   { "step": "setConfig", "name": "debug", "value": 32767, "plugin": "..." }
+ */
+class SetConfigStep extends AbstractStep
+{
+    public function run(RunContext $context, array $config, int $index): void
+    {
+        $name = $this->requireString($config, 'name');
+        $value = $this->coerceConfigValue($config['value'] ?? '');
+        $plugin = $this->optString($config, 'plugin');
+
+        self::apply($context, $name, $value, $plugin !== '' ? $plugin : null);
+    }
+
+    /**
+     * Apply a single config value through Moodle's CLI. Values are never logged
+     * (a config name may carry a secret such as an SMTP password).
+     */
+    public static function apply(RunContext $context, string $name, string $value, ?string $plugin = null): void
+    {
+        if (!preg_match('/^[a-zA-Z0-9_.\-]+$/', $name)) {
+            throw new BlueprintException(sprintf('Invalid config name "%s".', $name));
+        }
+
+        $args = ['--name=' . $name, '--set=' . $value];
+        if ($plugin !== null && $plugin !== '') {
+            if (!preg_match('/^[a-z][a-z0-9_]+$/', $plugin)) {
+                throw new BlueprintException(sprintf('Invalid plugin component "%s".', $plugin));
+            }
+            $args[] = '--component=' . $plugin;
+        }
+
+        $context->runMoodleCli('cfg.php', $args);
+        $context->logger()->info(sprintf('setConfig %s%s applied.', $plugin ? $plugin . '/' : '', $name));
+    }
+}

--- a/rootfs/usr/local/lib/moodle-blueprint/Steps/SetConfigsStep.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/Steps/SetConfigsStep.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace MoodleBlueprint\Steps;
+
+use MoodleBlueprint\BlueprintException;
+use MoodleBlueprint\RunContext;
+
+/**
+ * setConfigs — set several Moodle configuration values at once.
+ *
+ * Supports both shapes seen in the ecosystem:
+ *
+ *   Object map (alpine-moodle docs):
+ *     { "step": "setConfigs", "values": { "debug": 32767, "debugdisplay": 1 } }
+ *     { "step": "setConfigs", "configs": { "debug": 32767 } }
+ *
+ *   Array of descriptors (Moodle Playground):
+ *     { "step": "setConfigs", "configs": [ { "name": "debug", "value": 32767, "plugin": null } ] }
+ */
+class SetConfigsStep extends AbstractStep
+{
+    public function run(RunContext $context, array $config, int $index): void
+    {
+        $entries = $this->collectEntries($config);
+        if ($entries === []) {
+            throw new BlueprintException('setConfigs requires a non-empty "values" or "configs" map/array.');
+        }
+
+        foreach ($entries as $entry) {
+            SetConfigStep::apply($context, $entry['name'], $this->coerceConfigValue($entry['value']), $entry['plugin']);
+        }
+    }
+
+    /**
+     * Normalise the various accepted shapes into a list of
+     * ['name' => string, 'value' => mixed, 'plugin' => ?string].
+     *
+     * @param array<string,mixed> $config
+     * @return array<int,array{name:string,value:mixed,plugin:?string}>
+     */
+    private function collectEntries(array $config): array
+    {
+        $entries = [];
+
+        if (isset($config['values']) && is_array($config['values'])) {
+            foreach ($config['values'] as $name => $value) {
+                $entries[] = ['name' => (string) $name, 'value' => $value, 'plugin' => null];
+            }
+        }
+
+        if (isset($config['configs']) && is_array($config['configs'])) {
+            $configs = $config['configs'];
+            $isList = array_keys($configs) === range(0, count($configs) - 1);
+            if ($isList) {
+                foreach ($configs as $item) {
+                    if (!is_array($item) || !isset($item['name'])) {
+                        throw new BlueprintException('Each "configs" array entry must be an object with a "name".');
+                    }
+                    $entries[] = [
+                        'name' => (string) $item['name'],
+                        'value' => $item['value'] ?? '',
+                        'plugin' => isset($item['plugin']) && $item['plugin'] !== null ? (string) $item['plugin'] : null,
+                    ];
+                }
+            } else {
+                foreach ($configs as $name => $value) {
+                    $entries[] = ['name' => (string) $name, 'value' => $value, 'plugin' => null];
+                }
+            }
+        }
+
+        return $entries;
+    }
+}

--- a/rootfs/usr/local/lib/moodle-blueprint/Steps/SetThemeStep.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/Steps/SetThemeStep.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace MoodleBlueprint\Steps;
+
+use MoodleBlueprint\BlueprintException;
+use MoodleBlueprint\RunContext;
+
+/**
+ * setTheme — set the active Moodle theme.
+ *
+ * Accepts the alpine-moodle "theme" field and the Moodle Playground "name"
+ * field:
+ *   { "step": "setTheme", "theme": "boost" }
+ *   { "step": "setTheme", "name": "boost" }
+ */
+class SetThemeStep extends AbstractStep
+{
+    public function run(RunContext $context, array $config, int $index): void
+    {
+        $theme = $this->optString($config, 'theme');
+        if ($theme === '') {
+            $theme = $this->optString($config, 'name');
+        }
+        if ($theme === '') {
+            throw new BlueprintException('setTheme requires a "theme" (or "name") value.');
+        }
+        if (!preg_match('/^[a-z][a-z0-9_]+$/', $theme)) {
+            throw new BlueprintException(sprintf('Invalid theme name "%s".', $theme));
+        }
+
+        SetConfigStep::apply($context, 'theme', $theme);
+        $context->logger()->info(sprintf('Theme set to "%s".', $theme));
+    }
+}

--- a/rootfs/usr/local/lib/moodle-blueprint/Steps/StepInterface.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/Steps/StepInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace MoodleBlueprint\Steps;
+
+use MoodleBlueprint\RunContext;
+
+/**
+ * Contract implemented by every blueprint step handler.
+ */
+interface StepInterface
+{
+    /**
+     * Execute the step.
+     *
+     * @param array<string,mixed> $config The step object (including "step").
+     * @param int                 $index  Zero-based position in the steps array.
+     */
+    public function run(RunContext $context, array $config, int $index): void;
+}

--- a/rootfs/usr/local/lib/moodle-blueprint/autoload.php
+++ b/rootfs/usr/local/lib/moodle-blueprint/autoload.php
@@ -1,0 +1,22 @@
+<?php
+// Minimal PSR-4-style autoloader for the Moodle blueprint runner.
+//
+// All runner classes live under the `MoodleBlueprint\` namespace and are
+// resolved relative to this file's directory, so the same library works both
+// inside the container (/usr/local/lib/moodle-blueprint) and from the test
+// harness on a developer machine without any code changes.
+
+spl_autoload_register(static function ($class) {
+    $prefix = 'MoodleBlueprint\\';
+    if (strncmp($class, $prefix, strlen($prefix)) !== 0) {
+        return;
+    }
+
+    $relative = substr($class, strlen($prefix));
+    $relative = str_replace('\\', '/', $relative);
+    $file = __DIR__ . '/' . $relative . '.php';
+
+    if (is_file($file)) {
+        require $file;
+    }
+});

--- a/tests/blueprint/ArchiveTest.php
+++ b/tests/blueprint/ArchiveTest.php
@@ -48,6 +48,22 @@ it('rejects a ZIP-slip archive', function () use ($tmp, $policy) {
     assert_true(!is_file(dirname($tmp) . '/escape.txt'), 'no file written above tmp');
 });
 
+it('rejects an archive that decompresses past the size cap (zip bomb)', function () use ($tmp) {
+    // Tiny resource cap => maxArchiveSize() = 20 * cap = 20000 bytes.
+    $smallPolicy = new SecurityPolicy(true, false, 1000);
+    $zipPath = $tmp . '/bomb.zip';
+    $zip = new ZipArchive();
+    $zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+    // 50 KB of highly compressible data; inflated size exceeds the 20 KB cap.
+    $zip->addFromString('big.txt', str_repeat('A', 50000));
+    $zip->close();
+
+    $dest = $tmp . '/bomb-out';
+    assert_throws(BlueprintException::class, function () use ($smallPolicy, $zipPath, $dest) {
+        Archive::extract($smallPolicy, $zipPath, $dest);
+    }, 'zip bomb');
+});
+
 it('ignores __MACOSX metadata entries', function () use ($tmp, $policy) {
     $zipPath = $tmp . '/mac.zip';
     $zip = new ZipArchive();

--- a/tests/blueprint/ArchiveTest.php
+++ b/tests/blueprint/ArchiveTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Archive tests: ZIP-slip protection, __MACOSX handling and normal extraction.
+ * Skipped automatically when the PHP zip extension is unavailable.
+ */
+
+require __DIR__ . '/bootstrap.php';
+
+use MoodleBlueprint\Archive;
+use MoodleBlueprint\BlueprintException;
+use MoodleBlueprint\SecurityPolicy;
+
+if (!class_exists('ZipArchive')) {
+    fwrite(STDOUT, "  skip - ZipArchive not available; archive tests skipped\n");
+    return;
+}
+
+$tmp = sys_get_temp_dir() . '/bp-zip-' . getmypid();
+@mkdir($tmp, 0700, true);
+$policy = new SecurityPolicy();
+
+it('extracts a normal archive safely', function () use ($tmp, $policy) {
+    $zipPath = $tmp . '/good.zip';
+    $zip = new ZipArchive();
+    $zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+    $zip->addFromString('mod_demo/version.php', "<?php // version\n");
+    $zip->addFromString('mod_demo/lib.php', "<?php // lib\n");
+    $zip->close();
+
+    $dest = $tmp . '/good-out';
+    Archive::extract($policy, $zipPath, $dest);
+    assert_true(is_file($dest . '/mod_demo/version.php'), 'version.php extracted');
+    assert_true(is_file($dest . '/mod_demo/lib.php'), 'lib.php extracted');
+});
+
+it('rejects a ZIP-slip archive', function () use ($tmp, $policy) {
+    $zipPath = $tmp . '/evil.zip';
+    $zip = new ZipArchive();
+    $zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+    $zip->addFromString('../../escape.txt', "owned\n");
+    $zip->close();
+
+    $dest = $tmp . '/evil-out';
+    assert_throws(BlueprintException::class, function () use ($policy, $zipPath, $dest) {
+        Archive::extract($policy, $zipPath, $dest);
+    });
+    assert_true(!is_file($tmp . '/escape.txt'), 'no file written outside dest');
+    assert_true(!is_file(dirname($tmp) . '/escape.txt'), 'no file written above tmp');
+});
+
+it('ignores __MACOSX metadata entries', function () use ($tmp, $policy) {
+    $zipPath = $tmp . '/mac.zip';
+    $zip = new ZipArchive();
+    $zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+    $zip->addFromString('__MACOSX/._foo', "junk\n");
+    $zip->addFromString('real.txt', "content\n");
+    $zip->close();
+
+    $dest = $tmp . '/mac-out';
+    Archive::extract($policy, $zipPath, $dest);
+    assert_true(is_file($dest . '/real.txt'), 'real file extracted');
+    assert_true(!is_dir($dest . '/__MACOSX'), '__MACOSX ignored');
+});

--- a/tests/blueprint/BundleTest.php
+++ b/tests/blueprint/BundleTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Bundle tests: blueprint.json detection at the root or one directory deep,
+ * __MACOSX handling and ambiguity/missing errors (directory bundles).
+ */
+
+require __DIR__ . '/bootstrap.php';
+
+use MoodleBlueprint\BlueprintException;
+use MoodleBlueprint\Bundle;
+use MoodleBlueprint\Logger;
+use MoodleBlueprint\SecurityPolicy;
+
+$tmp = sys_get_temp_dir() . '/bp-bundle-' . getmypid();
+@mkdir($tmp, 0700, true);
+$policy = new SecurityPolicy();
+$logger = new Logger();
+
+/** Helper to create a directory with files. */
+$make = function (string $dir, array $files) {
+    @mkdir($dir, 0700, true);
+    foreach ($files as $rel => $content) {
+        $path = $dir . '/' . $rel;
+        @mkdir(dirname($path), 0700, true);
+        file_put_contents($path, $content);
+    }
+    return $dir;
+};
+
+it('detects blueprint.json at the bundle root', function () use ($make, $tmp, $policy, $logger) {
+    $dir = $make($tmp . '/root-bundle', ['blueprint.json' => '{"steps":[]}']);
+    $bundle = Bundle::open($policy, $dir, $tmp . '/wd1', $logger);
+    assert_eq($bundle->root(), $dir);
+    assert_eq($bundle->blueprintPath(), $dir . '/blueprint.json');
+});
+
+it('detects blueprint.json one directory deep, ignoring __MACOSX', function () use ($make, $tmp, $policy, $logger) {
+    $dir = $make($tmp . '/deep-bundle', [
+        'inner/blueprint.json' => '{"steps":[]}',
+        '__MACOSX/._inner' => 'junk',
+    ]);
+    $bundle = Bundle::open($policy, $dir, $tmp . '/wd2', $logger);
+    assert_eq($bundle->root(), $dir . '/inner');
+    assert_eq($bundle->blueprintPath(), $dir . '/inner/blueprint.json');
+});
+
+it('errors on ambiguous bundles', function () use ($make, $tmp, $policy, $logger) {
+    $dir = $make($tmp . '/ambiguous-bundle', [
+        'a/blueprint.json' => '{"steps":[]}',
+        'b/blueprint.json' => '{"steps":[]}',
+    ]);
+    assert_throws(BlueprintException::class, function () use ($policy, $dir, $tmp, $logger) {
+        Bundle::open($policy, $dir, $tmp . '/wd3', $logger);
+    }, 'Ambiguous');
+});
+
+it('errors when no blueprint.json is present', function () use ($make, $tmp, $policy, $logger) {
+    $dir = $make($tmp . '/empty-bundle', ['readme.txt' => 'nothing here']);
+    assert_throws(BlueprintException::class, function () use ($policy, $dir, $tmp, $logger) {
+        Bundle::open($policy, $dir, $tmp . '/wd4', $logger);
+    }, 'No blueprint.json');
+});
+
+it('errors when the bundle path does not exist', function () use ($tmp, $policy, $logger) {
+    assert_throws(BlueprintException::class, function () use ($policy, $tmp, $logger) {
+        Bundle::open($policy, $tmp . '/does-not-exist', $tmp . '/wd5', $logger);
+    }, 'does not exist');
+});

--- a/tests/blueprint/ParserTest.php
+++ b/tests/blueprint/ParserTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Parser tests: invalid JSON, missing steps, step validation, constants and
+ * the idempotency hash.
+ */
+
+require __DIR__ . '/bootstrap.php';
+
+use MoodleBlueprint\Blueprint;
+use MoodleBlueprint\BlueprintException;
+use MoodleBlueprint\BlueprintParser;
+
+$parser = new BlueprintParser();
+
+it('rejects invalid JSON', function () use ($parser) {
+    assert_throws(BlueprintException::class, function () use ($parser) {
+        $parser->parse('{ not valid json');
+    }, 'Invalid blueprint JSON');
+});
+
+it('rejects a non-object blueprint', function () use ($parser) {
+    assert_throws(BlueprintException::class, function () use ($parser) {
+        $parser->parse('[1, 2, 3]');
+    }, 'must be a JSON object');
+});
+
+it('rejects a blueprint without steps', function () use ($parser) {
+    assert_throws(BlueprintException::class, function () use ($parser) {
+        $parser->parse('{"landingPage": "/"}');
+    }, 'must contain a "steps" array');
+});
+
+it('rejects steps that are not an array', function () use ($parser) {
+    assert_throws(BlueprintException::class, function () use ($parser) {
+        $parser->parse('{"steps": {"step": "setConfig"}}');
+    }, 'must be an array');
+});
+
+it('rejects a step missing its "step" name', function () use ($parser) {
+    assert_throws(BlueprintException::class, function () use ($parser) {
+        $parser->parse('{"steps": [{"name": "debug"}]}');
+    }, 'non-empty "step" name');
+});
+
+it('accepts an empty steps array', function () use ($parser) {
+    $bp = $parser->parse('{"steps": []}');
+    assert_eq($bp->steps(), []);
+});
+
+it('preserves unknown top-level fields', function () use ($parser) {
+    $bp = $parser->parse('{"futureField": {"a": 1}, "steps": []}');
+    $data = $bp->data();
+    assert_true(isset($data['futureField']), 'unknown field preserved');
+    assert_eq($data['futureField']['a'], 1);
+});
+
+it('substitutes {{CONSTANTS}} in string values', function () use ($parser) {
+    $json = '{"constants": {"NAME": "Demo"}, "steps": [{"step": "createCategory", "name": "{{NAME}} Category"}]}';
+    $bp = $parser->parse($json);
+    assert_eq($bp->steps()[0]['name'], 'Demo Category');
+});
+
+it('leaves unknown placeholders untouched', function () use ($parser) {
+    $json = '{"constants": {"A": "x"}, "steps": [{"step": "setConfig", "name": "{{MISSING}}"}]}';
+    $bp = $parser->parse($json);
+    assert_eq($bp->steps()[0]['name'], '{{MISSING}}');
+});
+
+it('produces a stable hash regardless of key order or whitespace', function () use ($parser) {
+    $a = $parser->parse('{"landingPage":"/","steps":[{"step":"setConfig","name":"debug","value":1}]}');
+    $b = $parser->parse("{\n  \"steps\": [ { \"value\": 1, \"name\": \"debug\", \"step\": \"setConfig\" } ],\n  \"landingPage\": \"/\"\n}");
+    assert_eq($a->canonicalHash(), $b->canonicalHash(), 'hash is order/whitespace independent');
+});
+
+it('changes the hash when content changes', function () use ($parser) {
+    $a = $parser->parse('{"steps":[{"step":"setConfig","name":"debug","value":1}]}');
+    $b = $parser->parse('{"steps":[{"step":"setConfig","name":"debug","value":2}]}');
+    assert_true($a->canonicalHash() !== $b->canonicalHash(), 'different content => different hash');
+});
+
+it('parses the demo fixture and exposes resources/constants', function () use ($parser) {
+    $bp = $parser->parseFile(__DIR__ . '/fixtures/demo.blueprint.json');
+    assert_eq(count($bp->steps()), 5);
+    assert_eq($bp->landingPage(), '/course/index.php');
+    // Constant substituted into the category name.
+    assert_eq($bp->steps()[1]['name'], 'Blueprint demo');
+});

--- a/tests/blueprint/RegistryTest.php
+++ b/tests/blueprint/RegistryTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * StepRegistry tests: step classification and handler instantiation.
+ */
+
+require __DIR__ . '/bootstrap.php';
+
+use MoodleBlueprint\StepRegistry;
+use MoodleBlueprint\Steps\StepInterface;
+
+$registry = new StepRegistry();
+
+it('classifies implemented steps', function () use ($registry) {
+    foreach (['setConfig', 'setConfigs', 'createCourse', 'enrolUser', 'installMoodlePlugin'] as $name) {
+        assert_eq($registry->classify($name), StepRegistry::IMPLEMENTED, $name);
+    }
+});
+
+it('classifies container/browser steps as no-op', function () use ($registry) {
+    assert_eq($registry->classify('installMoodle'), StepRegistry::NOOP);
+    assert_eq($registry->classify('login'), StepRegistry::NOOP);
+});
+
+it('classifies unsafe steps', function () use ($registry) {
+    foreach (['runPhpCode', 'runPhpScript', 'writeFile', 'unzip', 'mkdir', 'request'] as $name) {
+        assert_eq($registry->classify($name), StepRegistry::UNSAFE, $name);
+    }
+});
+
+it('classifies recognised-but-unimplemented steps as planned', function () use ($registry) {
+    foreach (['restoreCourse', 'addModule', 'installLanguagePack', 'createRole'] as $name) {
+        assert_eq($registry->classify($name), StepRegistry::PLANNED, $name);
+    }
+});
+
+it('classifies truly unknown steps as unknown', function () use ($registry) {
+    assert_eq($registry->classify('totallyMadeUpStep'), StepRegistry::UNKNOWN);
+});
+
+it('returns a StepInterface handler for implemented steps', function () use ($registry) {
+    $handler = $registry->handler('setConfig');
+    assert_true($handler instanceof StepInterface, 'handler implements StepInterface');
+});
+
+it('lists exactly the implemented steps', function () use ($registry) {
+    $expected = [
+        'setConfig', 'setConfigs', 'setAdminAccount', 'installMoodlePlugin',
+        'installTheme', 'setTheme', 'createCategory', 'createCourse',
+        'createUser', 'createUsers', 'enrolUser',
+    ];
+    sort($expected);
+    $actual = $registry->implementedSteps();
+    sort($actual);
+    assert_eq($actual, $expected);
+});

--- a/tests/blueprint/ResourceResolverTest.php
+++ b/tests/blueprint/ResourceResolverTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * ResourceResolver tests: literal/base64/data-url descriptors, the "@name"
+ * reference syntax, size enforcement and bundled path safety.
+ */
+
+require __DIR__ . '/bootstrap.php';
+
+use MoodleBlueprint\BlueprintException;
+use MoodleBlueprint\Logger;
+use MoodleBlueprint\ResourceResolver;
+use MoodleBlueprint\SecurityPolicy;
+
+$workDir = sys_get_temp_dir() . '/bp-res-' . getmypid();
+@mkdir($workDir, 0700, true);
+$logger = new Logger();
+
+it('resolves a literal resource', function () use ($workDir, $logger) {
+    $resolver = new ResourceResolver(new SecurityPolicy(), $workDir, $logger);
+    $res = $resolver->resolve(['literal' => 'hello world']);
+    assert_eq($res->contents(), 'hello world');
+});
+
+it('json-encodes a literal object resource', function () use ($workDir, $logger) {
+    $resolver = new ResourceResolver(new SecurityPolicy(), $workDir, $logger);
+    $res = $resolver->resolve(['literal' => ['a' => 1]]);
+    assert_eq($res->contents(), '{"a":1}');
+});
+
+it('resolves a base64 resource', function () use ($workDir, $logger) {
+    $resolver = new ResourceResolver(new SecurityPolicy(), $workDir, $logger);
+    $res = $resolver->resolve(['base64' => base64_encode('binary-bytes')]);
+    assert_eq($res->contents(), 'binary-bytes');
+});
+
+it('rejects invalid base64', function () use ($workDir, $logger) {
+    $resolver = new ResourceResolver(new SecurityPolicy(), $workDir, $logger);
+    assert_throws(BlueprintException::class, function () use ($resolver) {
+        $resolver->resolve(['base64' => '!!!not base64!!!']);
+    });
+});
+
+it('resolves a base64 data URL', function () use ($workDir, $logger) {
+    $resolver = new ResourceResolver(new SecurityPolicy(), $workDir, $logger);
+    $res = $resolver->resolve(['data-url' => 'data:text/plain;base64,' . base64_encode('via-data-url')]);
+    assert_eq($res->contents(), 'via-data-url');
+});
+
+it('resolves a percent-encoded data URL', function () use ($workDir, $logger) {
+    $resolver = new ResourceResolver(new SecurityPolicy(), $workDir, $logger);
+    $res = $resolver->resolve(['data-url' => 'data:text/plain,hello%20world']);
+    assert_eq($res->contents(), 'hello world');
+});
+
+it('resolves "@name" references against the resources map', function () use ($workDir, $logger) {
+    $resolver = new ResourceResolver(new SecurityPolicy(), $workDir, $logger);
+    $resolver->setNamedResources(['readme' => ['literal' => 'from-map']]);
+    $res = $resolver->resolveReference('@readme');
+    assert_eq($res->contents(), 'from-map');
+});
+
+it('resolves inline descriptor references', function () use ($workDir, $logger) {
+    $resolver = new ResourceResolver(new SecurityPolicy(), $workDir, $logger);
+    $res = $resolver->resolveReference(['literal' => 'inline']);
+    assert_eq($res->contents(), 'inline');
+});
+
+it('rejects unknown "@name" references', function () use ($workDir, $logger) {
+    $resolver = new ResourceResolver(new SecurityPolicy(), $workDir, $logger);
+    assert_throws(BlueprintException::class, function () use ($resolver) {
+        $resolver->resolveReference('@missing');
+    }, 'Unknown resource reference');
+});
+
+it('rejects url resources when remote is disabled', function () use ($workDir, $logger) {
+    $resolver = new ResourceResolver(new SecurityPolicy(false), $workDir, $logger);
+    assert_throws(BlueprintException::class, function () use ($resolver) {
+        $resolver->resolve(['url' => 'https://example.com/x.zip']);
+    }, 'ALLOW_REMOTE_RESOURCES');
+});
+
+it('enforces the size limit on literal resources', function () use ($workDir, $logger) {
+    $resolver = new ResourceResolver(new SecurityPolicy(true, false, 4), $workDir, $logger);
+    assert_throws(BlueprintException::class, function () use ($resolver) {
+        $resolver->resolve(['literal' => 'too-long']);
+    }, 'limit');
+});
+
+it('rejects bundled references that escape the bundle', function () use ($workDir, $logger) {
+    $resolver = new ResourceResolver(new SecurityPolicy(), $workDir, $logger, '/srv/bundle');
+    assert_throws(BlueprintException::class, function () use ($resolver) {
+        $resolver->resolve(['bundled' => '../../etc/passwd']);
+    });
+});
+
+it('rejects bundled references when no bundle is set', function () use ($workDir, $logger) {
+    $resolver = new ResourceResolver(new SecurityPolicy(), $workDir, $logger);
+    assert_throws(BlueprintException::class, function () use ($resolver) {
+        $resolver->resolve(['bundled' => 'plugins/x.zip']);
+    }, 'no bundle');
+});
+
+it('rejects the browser-only vfs resource type', function () use ($workDir, $logger) {
+    $resolver = new ResourceResolver(new SecurityPolicy(), $workDir, $logger);
+    assert_throws(BlueprintException::class, function () use ($resolver) {
+        $resolver->resolve(['resource' => 'vfs', 'vfs' => '/x']);
+    }, 'vfs');
+});

--- a/tests/blueprint/RunnerTest.php
+++ b/tests/blueprint/RunnerTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * BlueprintRunner tests covering source selection, idempotency markers and
+ * fail-fast rejection of unknown/unsafe/planned steps.
+ *
+ * These never reach a Moodle-API step, so no bootstrapped Moodle is required.
+ */
+
+require __DIR__ . '/bootstrap.php';
+
+use MoodleBlueprint\Blueprint;
+use MoodleBlueprint\BlueprintException;
+use MoodleBlueprint\BlueprintParser;
+use MoodleBlueprint\BlueprintRunner;
+use MoodleBlueprint\Logger;
+use MoodleBlueprint\SecurityPolicy;
+
+$tmp = sys_get_temp_dir() . '/bp-runner-' . getmypid();
+@mkdir($tmp . '/wd', 0700, true);
+$logger = new Logger();
+
+/** Write a blueprint file and return its path. */
+$writeBlueprint = function (string $name, string $json) use ($tmp) {
+    $path = $tmp . '/' . $name;
+    file_put_contents($path, $json);
+    return $path;
+};
+
+$makeRunner = function (bool $force = false) use ($logger, $tmp) {
+    return new BlueprintRunner($logger, new SecurityPolicy(), '/var/www/html', $tmp, $tmp . '/wd', $force);
+};
+
+it('rejects an unknown step with clear context', function () use ($writeBlueprint, $makeRunner) {
+    $file = $writeBlueprint('unknown.json', '{"steps":[{"step":"doesNotExist"}]}');
+    assert_throws(BlueprintException::class, function () use ($makeRunner, $file) {
+        $makeRunner()->apply(null, $file, null);
+    }, 'unknown step type');
+});
+
+it('rejects an unsafe step by default', function () use ($writeBlueprint, $makeRunner) {
+    $file = $writeBlueprint('unsafe.json', '{"steps":[{"step":"runPhpCode","code":"echo 1;"}]}');
+    assert_throws(BlueprintException::class, function () use ($makeRunner, $file) {
+        $makeRunner()->apply(null, $file, null);
+    }, 'disabled by default');
+});
+
+it('rejects a planned step clearly', function () use ($writeBlueprint, $makeRunner) {
+    $file = $writeBlueprint('planned.json', '{"steps":[{"step":"addModule","module":"label","course":"X"}]}');
+    assert_throws(BlueprintException::class, function () use ($makeRunner, $file) {
+        $makeRunner()->apply(null, $file, null);
+    }, 'planned');
+});
+
+it('skips reapplication when the marker exists', function () use ($writeBlueprint, $makeRunner, $tmp) {
+    // A blueprint that would throw if any step ran.
+    $json = '{"steps":[{"step":"doesNotExist"}]}';
+    $file = $writeBlueprint('idem.json', $json);
+
+    // Pre-create the marker for this blueprint's hash.
+    $hash = (new BlueprintParser())->parse($json)->canonicalHash();
+    @mkdir($tmp . '/.blueprints', 0700, true);
+    file_put_contents($tmp . '/.blueprints/' . $hash . '.done', "hash={$hash}\n");
+
+    // apply() must short-circuit and NOT throw.
+    $result = $makeRunner()->apply(null, $file, null);
+    assert_true($result === true, 'apply returned true on already-applied');
+});
+
+it('reapplies (and fails on the bad step) when force is set', function () use ($writeBlueprint, $makeRunner, $tmp) {
+    $json = '{"steps":[{"step":"doesNotExist"}]}';
+    $file = $writeBlueprint('idem2.json', $json);
+    $hash = (new BlueprintParser())->parse($json)->canonicalHash();
+    @mkdir($tmp . '/.blueprints', 0700, true);
+    file_put_contents($tmp . '/.blueprints/' . $hash . '.done', "hash={$hash}\n");
+
+    assert_throws(BlueprintException::class, function () use ($makeRunner, $file) {
+        $makeRunner(true)->apply(null, $file, null); // force=true
+    }, 'unknown step type');
+});
+
+it('errors when no source is provided', function () use ($makeRunner) {
+    assert_throws(BlueprintException::class, function () use ($makeRunner) {
+        $makeRunner()->apply(null, null, null);
+    }, 'No blueprint source');
+});
+
+it('validate() summarises step classifications without applying', function () use ($writeBlueprint, $makeRunner) {
+    $json = '{"steps":[' .
+        '{"step":"setConfig","name":"debug","value":1},' .
+        '{"step":"installMoodle"},' .
+        '{"step":"addModule"},' .
+        '{"step":"runPhpCode"},' .
+        '{"step":"madeUp"}' .
+        ']}';
+    $file = $writeBlueprint('validate.json', $json);
+    $summary = $makeRunner()->validate(null, $file, null);
+    assert_eq($summary['implemented'] ?? 0, 1);
+    assert_eq($summary['noop'] ?? 0, 1);
+    assert_eq($summary['planned'] ?? 0, 1);
+    assert_eq($summary['unsafe'] ?? 0, 1);
+    assert_eq($summary['unknown'] ?? 0, 1);
+});

--- a/tests/blueprint/SecurityPolicyTest.php
+++ b/tests/blueprint/SecurityPolicyTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * SecurityPolicy tests: size parsing, remote toggles, path traversal and the
+ * Moodle path allowlist.
+ */
+
+require __DIR__ . '/bootstrap.php';
+
+use MoodleBlueprint\BlueprintException;
+use MoodleBlueprint\SecurityPolicy;
+
+it('parses human-readable sizes', function () {
+    assert_eq(SecurityPolicy::parseSize('50M'), 50 * 1024 * 1024);
+    assert_eq(SecurityPolicy::parseSize('10k'), 10 * 1024);
+    assert_eq(SecurityPolicy::parseSize('1G'), 1024 * 1024 * 1024);
+    assert_eq(SecurityPolicy::parseSize('1024'), 1024);
+});
+
+it('rejects invalid sizes', function () {
+    assert_throws(BlueprintException::class, function () {
+        SecurityPolicy::parseSize('not-a-size');
+    });
+});
+
+it('rejects remote resources when disabled', function () {
+    $policy = new SecurityPolicy(false);
+    assert_throws(BlueprintException::class, function () use ($policy) {
+        $policy->assertRemoteAllowed('https://example.com/x.zip');
+    }, 'ALLOW_REMOTE_RESOURCES');
+});
+
+it('rejects non-http(s) schemes even when remote is allowed', function () {
+    $policy = new SecurityPolicy(true);
+    assert_throws(BlueprintException::class, function () use ($policy) {
+        $policy->assertRemoteAllowed('file:///etc/passwd');
+    }, 'scheme');
+});
+
+it('enforces the size limit', function () {
+    $policy = new SecurityPolicy(true, false, 100);
+    $policy->assertWithinSizeLimit(100, 'thing'); // boundary ok
+    assert_throws(BlueprintException::class, function () use ($policy) {
+        $policy->assertWithinSizeLimit(101, 'thing');
+    }, 'limit');
+});
+
+it('normalises paths lexically', function () {
+    assert_eq(SecurityPolicy::normalizePath('/a/b/../c'), '/a/c');
+    assert_eq(SecurityPolicy::normalizePath('/a/./b/'), '/a/b');
+    assert_eq(SecurityPolicy::normalizePath('/a/b/../../..'), '/');
+});
+
+it('rejects parent-directory traversal in safeJoin', function () {
+    $policy = new SecurityPolicy();
+    assert_throws(BlueprintException::class, function () use ($policy) {
+        $policy->safeJoin('/srv/bundle', '../../etc/passwd');
+    }, 'escapes');
+});
+
+it('rejects absolute resource paths in safeJoin', function () {
+    $policy = new SecurityPolicy();
+    assert_throws(BlueprintException::class, function () use ($policy) {
+        $policy->safeJoin('/srv/bundle', '/etc/passwd');
+    }, 'Absolute');
+});
+
+it('accepts safe relative paths in safeJoin', function () {
+    $policy = new SecurityPolicy();
+    assert_eq($policy->safeJoin('/srv/bundle', 'plugins/mod_x.zip'), '/srv/bundle/plugins/mod_x.zip');
+});
+
+it('allows writes only under allowlisted Moodle paths', function () {
+    $policy = new SecurityPolicy(true, false, 1024, ['/var/www/html']);
+    $policy->assertAllowedMoodlePath('/var/www/html/mod/demo'); // ok
+    assert_throws(BlueprintException::class, function () use ($policy) {
+        $policy->assertAllowedMoodlePath('/etc/cron.d/evil');
+    }, 'allowlisted');
+});
+
+it('rejects ZIP entries that attempt traversal', function () {
+    $policy = new SecurityPolicy();
+    foreach (['../evil', '/abs/evil', 'a/../../b', 'win\\path'] as $bad) {
+        assert_throws(BlueprintException::class, function () use ($policy, $bad) {
+            $policy->assertSafeArchiveEntry($bad);
+        });
+    }
+    // A normal nested entry is accepted.
+    $policy->assertSafeArchiveEntry('mod_demo/version.php');
+});

--- a/tests/blueprint/bootstrap.php
+++ b/tests/blueprint/bootstrap.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Minimal, dependency-free test harness for the Moodle blueprint runner.
+ *
+ * These tests exercise the pure (non-Moodle) parts of the runner — parser,
+ * security policy, resource resolver, registry, archive safety and the
+ * idempotency hash — so they run with a plain `php` binary and need neither
+ * PHPUnit nor a bootstrapped Moodle.
+ *
+ * Each test file requires this bootstrap, declares cases with it(), and exits
+ * with a non-zero status if any case fails (handled by the shutdown function).
+ */
+
+$repoRoot = dirname(__DIR__, 2);
+require $repoRoot . '/rootfs/usr/local/lib/moodle-blueprint/autoload.php';
+
+final class TestRunner
+{
+    /** @var int */
+    public static $passed = 0;
+    /** @var int */
+    public static $failed = 0;
+
+    public static function it(string $name, callable $fn): void
+    {
+        try {
+            $fn();
+            self::$passed++;
+            fwrite(STDOUT, "  ok   - {$name}\n");
+        } catch (\Throwable $e) {
+            self::$failed++;
+            fwrite(STDOUT, "  FAIL - {$name}: " . $e->getMessage() . "\n");
+        }
+    }
+}
+
+function it(string $name, callable $fn): void
+{
+    TestRunner::it($name, $fn);
+}
+
+function assert_true($cond, string $message = 'expected true'): void
+{
+    if (!$cond) {
+        throw new \Exception($message);
+    }
+}
+
+function assert_eq($actual, $expected, string $message = ''): void
+{
+    if ($actual !== $expected) {
+        throw new \Exception(
+            ($message !== '' ? $message . ': ' : '') .
+            'expected ' . var_export($expected, true) . ' but got ' . var_export($actual, true)
+        );
+    }
+}
+
+function assert_contains(string $haystack, string $needle, string $message = ''): void
+{
+    if (strpos($haystack, $needle) === false) {
+        throw new \Exception(($message !== '' ? $message . ': ' : '') . "'{$needle}' not found in '{$haystack}'");
+    }
+}
+
+/**
+ * Assert that running $fn throws an exception of $class (optionally with a
+ * message containing $contains).
+ */
+function assert_throws(string $class, callable $fn, ?string $contains = null): void
+{
+    try {
+        $fn();
+    } catch (\Throwable $e) {
+        if (!($e instanceof $class)) {
+            throw new \Exception("expected {$class} but caught " . get_class($e) . ': ' . $e->getMessage());
+        }
+        if ($contains !== null) {
+            assert_contains($e->getMessage(), $contains, 'exception message');
+        }
+        return;
+    }
+    throw new \Exception("expected {$class} to be thrown, but nothing was thrown");
+}
+
+register_shutdown_function(static function () {
+    fwrite(STDOUT, sprintf("  -> %d passed, %d failed\n", TestRunner::$passed, TestRunner::$failed));
+    if (TestRunner::$failed > 0) {
+        exit(1);
+    }
+});

--- a/tests/blueprint/fixtures/demo.blueprint.json
+++ b/tests/blueprint/fixtures/demo.blueprint.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ateeducacion/moodle-playground/main/assets/blueprints/blueprint-schema.json",
+  "preferredVersions": {
+    "php": "8.3",
+    "moodle": "5.0"
+  },
+  "landingPage": "/course/index.php",
+  "constants": {
+    "DEMO_CATEGORY": "Blueprint demo"
+  },
+  "steps": [
+    {
+      "step": "setConfig",
+      "name": "debug",
+      "value": 32767
+    },
+    {
+      "step": "createCategory",
+      "name": "{{DEMO_CATEGORY}}",
+      "idnumber": "blueprint-demo"
+    },
+    {
+      "step": "createCourse",
+      "fullname": "Blueprint demo course",
+      "shortname": "BLUEPRINT101",
+      "category": "blueprint-demo"
+    },
+    {
+      "step": "createUser",
+      "username": "student1",
+      "password": "ChangeMe123!",
+      "email": "student1@example.com",
+      "firstname": "Student",
+      "lastname": "One"
+    },
+    {
+      "step": "enrolUser",
+      "username": "student1",
+      "course": "BLUEPRINT101",
+      "role": "student"
+    }
+  ]
+}

--- a/tests/blueprint/run.sh
+++ b/tests/blueprint/run.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+#
+# Run the Moodle blueprint runner checks:
+#   1. PHP lint of every runner file.
+#   2. POSIX shell syntax check of the entrypoint hook.
+#   3. The dependency-free PHP unit tests.
+#
+# Usage: tests/blueprint/run.sh   (override the interpreter with PHP=php8.3)
+#
+set -eu
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$DIR/../.." && pwd)"
+PHP="${PHP:-php}"
+LIB="$ROOT/rootfs/usr/local/lib/moodle-blueprint"
+fail=0
+
+echo "== PHP lint =="
+for f in $(find "$LIB" -name '*.php' | sort); do
+    if "$PHP" -l "$f" >/dev/null 2>&1; then
+        echo "  ok   - ${f#"$ROOT/"}"
+    else
+        echo "  FAIL - ${f#"$ROOT/"}"
+        "$PHP" -l "$f" || true
+        fail=1
+    fi
+done
+if "$PHP" -l "$ROOT/rootfs/usr/local/bin/moodle-blueprint" >/dev/null 2>&1; then
+    echo "  ok   - rootfs/usr/local/bin/moodle-blueprint"
+else
+    echo "  FAIL - rootfs/usr/local/bin/moodle-blueprint"
+    fail=1
+fi
+
+echo "== Shell syntax =="
+if sh -n "$ROOT/rootfs/docker-entrypoint-init.d/03-apply-blueprint.sh"; then
+    echo "  ok   - 03-apply-blueprint.sh"
+else
+    echo "  FAIL - 03-apply-blueprint.sh"
+    fail=1
+fi
+
+echo "== Unit tests =="
+for t in "$DIR"/*Test.php; do
+    echo "- $(basename "$t")"
+    if ! "$PHP" "$t"; then
+        fail=1
+    fi
+done
+
+echo "============================"
+if [ "$fail" -eq 0 ]; then
+    echo "ALL BLUEPRINT CHECKS PASSED"
+    exit 0
+fi
+echo "BLUEPRINT CHECKS FAILED"
+exit 1


### PR DESCRIPTION
## Summary

Adds experimental support for applying Moodle Playground-compatible `blueprint.json` files during `alpine-moodle` startup.

This allows the same declarative Moodle scenario to be used with:

- `moodle-playground` for browser-based QA, demos, and shareable test cases.
- `alpine-moodle` for Docker-based development, CI, plugin development, integration testing, and persistent environments.

The two projects are positioned as complementary **sibling** runtimes. Blueprint support is an additional declarative provisioning layer — it does **not** replace the existing environment-variable configuration.

## What is included

- New `MOODLE_BLUEPRINT`, `MOODLE_BLUEPRINT_URL`, and `MOODLE_BLUEPRINT_BUNDLE` inputs (plus `MOODLE_BLUEPRINT_FORCE`, `MOODLE_BLUEPRINT_ON_ERROR`, `MOODLE_BLUEPRINT_ALLOW_REMOTE_RESOURCES`, `MOODLE_BLUEPRINT_ALLOW_UNSAFE_STEPS`, `MOODLE_BLUEPRINT_MAX_RESOURCE_SIZE`).
- New startup hook `rootfs/docker-entrypoint-init.d/03-apply-blueprint.sh` that runs after Moodle is installed/upgraded and honours `MOODLE_BLUEPRINT_ON_ERROR` (`abort`/`warn`).
- New `moodle-blueprint` PHP runner under `rootfs/usr/local/bin/` + `rootfs/usr/local/lib/moodle-blueprint/`, structured as parser / security policy / resource resolver / bundle / step registry / runner + step handlers.
- Safe resource resolution for local files, URLs, base64, data URLs, literals, and bundled resources, with caching, size limits and remote toggles.
- Blueprint bundles (directory or ZIP; `blueprint.json` at root or one directory deep; `__MACOSX` ignored).
- Idempotency marker under `/var/www/moodledata/.blueprints/<sha256>.done`.
- `php83-zip` added to the image for safe `ZipArchive`-based extraction.

## Supported steps

`setConfig`, `setConfigs`, `setAdminAccount`, `installMoodlePlugin`, `installTheme`, `setTheme`, `createCategory`, `createCourse`, `createUser`, `createUsers`, `enrolUser`.

`installMoodle` and `login` are loud no-ops (handled by the container / browser-only). `restoreCourse` and other recognised Moodle Playground steps are reported as **planned** and fail clearly.

## Safety

Unsafe steps (`runPhpCode`, `runPhpScript`, `runCli`, `request`, `writeFile`, `writeFiles`, `unzip`, `mkdir`, `rmdir`, `copyFile`, `moveFile`) are disabled by default. No `eval`; shell-outs use `escapeshellarg()`; passwords are never logged; ZIP extraction is ZIP-slip-proof and never honours symlink entries; bundle paths cannot escape the bundle; plugin writes are restricted to allowlisted Moodle directories; remote resources are bounded by size and can be disabled. Unsupported steps fail explicitly instead of being silently ignored.

## Documentation

- New `docs/blueprints.md` (full guide, env var table, compatibility matrix, security model, idempotency, bundles, manual validation), linked from the README and the mkdocs nav.
- New README "Moodle Playground Blueprints" section positioning the sibling runtimes.
- Copy-pasteable examples under `docs/examples/` (the shared demo blueprint + a bundle layout).

## Validation

- `tests/blueprint/run.sh`: PHP lint of all 28 runner files, `sh -n` of the entrypoint hook, and **59 dependency-free PHP unit tests** (parser, security policy, resource resolver, archive ZIP-slip, bundle detection, step registry, runner idempotency) — all passing.
- New `blueprint-tests` GitHub workflow runs the same checks on PRs.
- Manual end-to-end validation commands are documented in `docs/blueprints.md`.
