### PR TITLE
Fix moosh on Moodle 5.1+ (target the public/ code root)

### DIFF
--- a/rootfs/usr/local/bin/moosh
+++ b/rootfs/usr/local/bin/moosh
@@ -25,7 +25,27 @@ foreach ($argv as $arg) {
     }
 }
 
-// Insert -p /var/www/html before the first non-option argument (the subcommand)
+// Resolve the Moodle code root (dirroot) that moosh should target.
+//
+// Since Moodle 5.1, the web-accessible files (and version.php / lib/) live
+// inside a "public/" subdirectory, so the codebase root moved from
+// /var/www/html to /var/www/html/public. moosh detects a Moodle install by
+// its version.php, so on 5.1+ it must be pointed at the public/ directory
+// (whose config.php in turn requires the parent /var/www/html/config.php).
+//
+// On the legacy (pre-5.1) layout we also force session_handler_class=unset,
+// which avoids CLI session-handler errors. On 5.1+ that same override makes
+// moosh bootstrap silently produce no output, so it is omitted there.
+// Auto-detect the layout so both work.
+$moodlePath = '/var/www/html';
+$extraOptions = ['-o', 'session_handler_class=unset'];
+if (is_file('/var/www/html/public/version.php')) {
+    $moodlePath = '/var/www/html/public';
+    $extraOptions = [];
+}
+
+// Insert -p <moodlePath> (+ any extra options) before the first non-option
+// argument (the subcommand).
 if (!$hasMoodlePath) {
     $insertAt = 0;
     foreach ($argv as $i => $arg) {
@@ -34,7 +54,7 @@ if (!$hasMoodlePath) {
             break;
         }
     }
-    array_splice($argv, $insertAt, 0, ['-p', '/var/www/html', '-o', 'session_handler_class=unset']);
+    array_splice($argv, $insertAt, 0, array_merge(['-p', $moodlePath], $extraOptions));
 }
 
 array_unshift($argv, $script);


### PR DESCRIPTION
## Summary

`moosh` is broken on Moodle 5.1+ because the wrapper points it at the wrong directory. Since Moodle 5.1 the web-accessible files — including `version.php` — moved into a `public/` subdirectory, so the code root that moosh must target is `/var/www/html/public` (whose `config.php` `require`s the parent `/var/www/html/config.php`), not `/var/www/html`.

The wrapper hardcoded `-p /var/www/html`, where 5.1 has no `version.php`, so moosh cannot detect a Moodle install and falls back to listing only its no-bootstrap "global" commands:

```
moosh version 1.46
No command provided, possible commands in current context:
	generate-moosh
	nginx-parse-extendedlog
```

Every Moodle-context command (`user-create`, `role-list`, `user-assign-system-role`, `sql-run`, …) therefore fails. When such a command is used in `POST_CONFIGURE_COMMANDS`, its non-zero exit aborts the init script; the container then exits (code 10) and **crash-loops** under `restart: unless-stopped`, so nginx never starts and the site never becomes reachable. On 4.5.x / 5.0.x (no `public/`) everything works, which is why only 5.1+ is affected.

## Fix

- Auto-detect the layout via `/var/www/html/public/version.php`. On 5.1+, target `/var/www/html/public`; otherwise keep `/var/www/html`.
- The wrapper's forced `-o session_handler_class=unset` (which avoids CLI session-handler errors on the legacy layout) makes moosh bootstrap **silently produce no output** on 5.1+, so it is omitted there. Pre-5.1 behavior is unchanged.

Single-file change to `rootfs/usr/local/bin/moosh`.

## Verification

Reproduced and fixed against `erseco/alpine-moodle:v5.1.5` locally.

Before (current wrapper, `-p /var/www/html` hardcoded):
```
$ moosh role-list
No command provided, possible commands in current context: (global-only list)
```

After (this fix, plain auto-detect invocation as POST_CONFIGURE uses):
```
$ moosh role-list           -> prints the roles table, exit 0
$ moosh user-create ... student  -> "4" (created), exit 0
$ moosh user-assign-system-role student manager -> "OK!", exit 0
$ moosh sql-run "SELECT ..."     -> rows, exit 0
```

Root cause confirmed by inspecting the container: `/var/www/html/version.php` is absent on 5.1 while `/var/www/html/public/version.php` exists, and `/var/www/html/public/config.php` does `require_once(__DIR__ . '/../config.php')`, which is why targeting `public/` bootstraps moosh with the correct DB config.

## Impact

Unblocks any downstream project whose `POST_CONFIGURE_COMMANDS` use moosh against a Moodle 5.1+ image (e.g. CI suites that create test users/roles). No change for pre-5.1 layouts.

## Notes for reviewers

- `rootfs/usr/local/bin/moosh` is marked `binary` in `.gitattributes` (line-ending protection); it is plain PHP text — use `git diff --text` to review.
- Follow-up worth considering separately: make the init script resilient so a failing `POST_CONFIGURE_COMMANDS` logs and continues (and/or starts nginx) instead of crash-looping the whole container. Out of scope for this focused fix.