### PR TITLE
Test Moodle builds across supported version matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,21 +98,22 @@ jobs:
         run: |
           docker buildx build --load .
 
-      # Step 9: Test the built image with PostgreSQL (default)
+      # Steps 9x: Functional tests (HTTP web check + Moodle-context moosh smoke
+      # test) via the shared orchestrator tests/compose-test.sh. On pull requests
+      # the dedicated moodle-matrix workflow already runs these across every
+      # supported Moodle version, so here they run only on push/dispatch as a
+      # release smoke test (Moodle main, the default MOODLE_VERSION).
       - name: Test (PostgreSQL)
-        run: |
-          docker compose version
-          docker compose --file docker-compose.test.yml up --exit-code-from sut --timeout 10 --build
+        if: github.event_name != 'pull_request'
+        run: ./tests/compose-test.sh docker-compose.test.yml
 
-      # Step 9b: Test with MariaDB
       - name: Test (MariaDB)
-        run: |
-          docker compose --file docker-compose.test.mariadb.yml up --exit-code-from sut --timeout 10 --build
+        if: github.event_name != 'pull_request'
+        run: ./tests/compose-test.sh docker-compose.test.mariadb.yml
 
-      # Step 9c: Test with SQLite
       - name: Test (SQLite)
-        run: |
-          docker compose --file docker-compose.test.sqlite.yml up --exit-code-from sut --timeout 10 --build
+        if: github.event_name != 'pull_request'
+        run: ./tests/compose-test.sh docker-compose.test.sqlite.yml
 
       # Step 10: Build and Push to both registries in a single step
       - name: Build and push

--- a/.github/workflows/moodle-matrix-tests.yml
+++ b/.github/workflows/moodle-matrix-tests.yml
@@ -1,0 +1,77 @@
+name: moodle-matrix
+
+# Build and test the image across the supported Moodle version matrix so a
+# change cannot silently break a supported release or a specific layout.
+#
+# Layout coverage:
+#   - legacy (pre-5.1):  v4.5.x, v5.0.x
+#   - public/ (5.1+):    v5.1.x, v5.2.x, main (upcoming 5.3 line)
+#
+# Each job verifies that Moodle is reachable over HTTP AND that a Moodle-context
+# moosh command works (guards against the PR #149 regression). Version tags are
+# pinned to the latest available patch releases (there is no bare vX.Y tag); see
+# specs/ci-moodle-version-matrix.md.
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+# Cancel superseded runs on the same ref to save CI minutes.
+concurrency:
+  group: moodle-matrix-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # PostgreSQL (the default backend) covers every Moodle version.
+  postgres:
+    name: "Moodle ${{ matrix.moodle }} · PostgreSQL"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        moodle: [v4.5.12, v5.0.8, v5.1.5, v5.2.1, main]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Test PostgreSQL · Moodle ${{ matrix.moodle }}
+        env:
+          MOODLE_VERSION: ${{ matrix.moodle }}
+        run: ./tests/compose-test.sh docker-compose.test.yml
+
+  # MariaDB on a representative subset: one legacy + one public/ layout.
+  mariadb:
+    name: "Moodle ${{ matrix.moodle }} · MariaDB"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        moodle: [v4.5.12, v5.2.1]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Test MariaDB · Moodle ${{ matrix.moodle }}
+        env:
+          MOODLE_VERSION: ${{ matrix.moodle }}
+        run: ./tests/compose-test.sh docker-compose.test.mariadb.yml
+
+  # SQLite on a representative subset: one legacy + one public/ layout.
+  # SQLite patches only exist for Moodle 5.0+, so 4.5 is intentionally excluded.
+  sqlite:
+    name: "Moodle ${{ matrix.moodle }} · SQLite"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        moodle: [v5.0.8, main]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Test SQLite · Moodle ${{ matrix.moodle }}
+        env:
+          MOODLE_VERSION: ${{ matrix.moodle }}
+        run: ./tests/compose-test.sh docker-compose.test.sqlite.yml

--- a/.github/workflows/moodle-matrix-tests.yml
+++ b/.github/workflows/moodle-matrix-tests.yml
@@ -58,8 +58,15 @@ jobs:
           MOODLE_VERSION: ${{ matrix.moodle }}
         run: ./tests/compose-test.sh docker-compose.test.mariadb.yml
 
-  # SQLite on a representative subset: one legacy + one public/ layout.
-  # SQLite patches only exist for Moodle 5.0+, so 4.5 is intentionally excluded.
+  # SQLite covers the versions where the experimental SQLite patch actually
+  # yields a working install: v5.2.x and main (both use ateeducacion/moodle
+  # PR #1). Other versions are intentionally NOT covered:
+  #   - 4.5 has no SQLite patch at all.
+  #   - 5.0 (PR #3) and 5.1 (PR #2) install-fail with "Error reading environment
+  #     data" (PostgreSQL on those versions passes, so it is the patch, not the
+  #     layout or this change).
+  # See specs/ci-moodle-version-matrix.md. Fixing those SQLite patches is out of
+  # scope for this CI change.
   sqlite:
     name: "Moodle ${{ matrix.moodle }} · SQLite"
     runs-on: ubuntu-latest
@@ -67,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        moodle: [v5.0.8, main]
+        moodle: [v5.2.1, main]
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/docker-compose.test.mariadb.yml
+++ b/docker-compose.test.mariadb.yml
@@ -4,7 +4,9 @@ services:
     build:
       context: .
       args:
-        MOODLE_VERSION: main
+        # Set MOODLE_VERSION in the environment to test a specific git tag;
+        # defaults to main.
+        MOODLE_VERSION: ${MOODLE_VERSION:-main}
     environment:
       - SITE_URL=http://app:8080
       - DB_TYPE=mariadb
@@ -13,6 +15,9 @@ services:
       - DB_NAME=moodle
       - DB_USER=moodle
       - DB_PASS=moodle
+    # Mounted so the moosh smoke test can run inside app (see docker-compose.test.yml).
+    volumes:
+      - "./run_tests.sh:/tmp/run_tests.sh:ro"
     depends_on:
       - mariadb
 

--- a/docker-compose.test.sqlite.yml
+++ b/docker-compose.test.sqlite.yml
@@ -4,12 +4,16 @@ services:
     build:
       context: .
       args:
-        MOODLE_VERSION: main
+        # Set MOODLE_VERSION in the environment to test a specific git tag;
+        # defaults to main. SQLite patches only exist for Moodle 5.0+.
+        MOODLE_VERSION: ${MOODLE_VERSION:-main}
     environment:
       - SITE_URL=http://app:8080
       - MOODLE_DATABASE_TYPE=sqlite3
     volumes:
       - moodledata:/var/www/moodledata
+      # Mounted so the moosh smoke test can run inside app (see docker-compose.test.yml).
+      - "./run_tests.sh:/tmp/run_tests.sh:ro"
 
   sut:
     image: alpine:latest

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -4,16 +4,19 @@ services:
     build:
       context: .
       args:
-        # To use a specific Moodle version, set MOODLE_VERSION to git release tag.
-        # You can find the list of available tags at:
-        # https://api.github.com/repos/moodle/moodle/tags
+        # Moodle version to build. Set MOODLE_VERSION in the environment (e.g. in
+        # CI) to a git release tag to test a specific version; defaults to main.
+        # Available tags: https://api.github.com/repos/moodle/moodle/tags
         #
         # Example:
-        # MOODLE_VERSION: v4.5.3
-        # MOODLE_VERSION: v5.0.1
-        MOODLE_VERSION: main
+        # MOODLE_VERSION=v4.5.12 docker compose -f docker-compose.test.yml up --build
+        MOODLE_VERSION: ${MOODLE_VERSION:-main}
     environment:
       - SITE_URL=http://app:8080
+    # Mounted so the Moodle-context moosh smoke test can be run inside app:
+    #   docker compose -f docker-compose.test.yml exec app sh /tmp/run_tests.sh moosh
+    volumes:
+      - "./run_tests.sh:/tmp/run_tests.sh:ro"
     depends_on:
       - postgres
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,13 +1,98 @@
 #!/usr/bin/env sh
 set -eu
 
+# run_tests.sh [MODE]
+#
+#   MODE=all (default)
+#     Black-box readiness + HTTP web check. Runs from the `sut` container against
+#     the `app` service: waits for the port, then asserts an HTTP 200 homepage
+#     carrying stable Moodle markers. Also verifies the SQLite DB file when
+#     DB_TYPE=sqlite3.
+#
+#   MODE=moosh
+#     Moodle-context `moosh` smoke test. Must run INSIDE the `app` container,
+#     because moosh needs the Moodle codebase and DB access, which only exist
+#     there. Fails if moosh cannot bootstrap Moodle (the PR #149 regression on
+#     the 5.1+ public/ layout).
+MODE="${1:-all}"
+
+# --------------------------------------------------------------------------
+# Moodle-context moosh smoke test
+# --------------------------------------------------------------------------
+run_moosh_smoke_test() {
+  echo "== Moodle-context moosh smoke test =="
+
+  # Diagnostics: report the detected code root and the build version so a failure
+  # immediately shows which layout / version was under test.
+  if [ -f /var/www/html/public/version.php ]; then
+    echo "Layout: Moodle 5.1+ public/ (code root: /var/www/html/public)"
+  else
+    echo "Layout: legacy pre-5.1 (code root: /var/www/html)"
+  fi
+  echo "MOODLE_VERSION (build arg): ${MOODLE_VERSION:-<unset>}"
+
+  if ! command -v moosh >/dev/null 2>&1; then
+    echo "ERROR: moosh not found in PATH; this mode must run inside the app container."
+    exit 1
+  fi
+
+  # role-list requires a bootstrapped Moodle + DB. If moosh cannot detect the
+  # Moodle install it prints only its global commands ("No command provided,
+  # possible commands in current context: ..."), which is exactly the PR #149
+  # regression on the 5.1+ public/ layout. role-list is read-only, deterministic
+  # and works across Moodle 4.5 -> main.
+  echo "Running: moosh role-list"
+  set +e
+  moosh_output="$(moosh role-list 2>&1)"
+  moosh_rc=$?
+  set -e
+
+  echo "----- moosh role-list output (rc=${moosh_rc}) -----"
+  echo "$moosh_output"
+  echo "---------------------------------------------------"
+
+  if [ "$moosh_rc" -ne 0 ]; then
+    echo "ERROR: 'moosh role-list' exited with code ${moosh_rc}."
+    exit 1
+  fi
+
+  if echo "$moosh_output" | grep -qiE 'No command provided|possible commands in current context'; then
+    echo "ERROR: moosh returned its global/no-bootstrap command list; Moodle context did not load."
+    echo "This is the PR #149 regression (moosh pointed at the wrong code root)."
+    exit 1
+  fi
+
+  # A bootstrapped site always exposes the standard archetype roles. Their
+  # shortnames are not localised, so this is stable across versions/languages.
+  if ! echo "$moosh_output" | grep -qiE '(manager|editingteacher|student|guest)'; then
+    echo "ERROR: moosh role-list did not list the standard Moodle roles; unexpected output."
+    exit 1
+  fi
+
+  echo "moosh Moodle-context smoke test passed."
+}
+
+if [ "$MODE" = "moosh" ]; then
+  run_moosh_smoke_test
+  exit 0
+fi
+
+# --------------------------------------------------------------------------
+# Default: black-box readiness + HTTP web check
+# --------------------------------------------------------------------------
 apk --no-cache add curl
 
-# Check that the database is available
+# Wait for the app port to open, bounded by a deadline so a build that never
+# starts (crash-loop / broken layout) fails cleanly instead of hanging forever.
 echo "Waiting for moodle to be ready"
+deadline=$(( $(date +%s) + 600 ))   # up to 10 minutes for first-boot install
 while ! nc -w 1 app 8080; do
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+        echo "ERROR: app:8080 did not open within 10 minutes; Moodle failed to start."
+        exit 1
+    fi
     # Show some progress
-    echo -n '.';
+    printf '.';
     sleep 1;
 done
 echo "moodle is ready"

--- a/specs/ci-moodle-version-matrix.md
+++ b/specs/ci-moodle-version-matrix.md
@@ -1,0 +1,116 @@
+# Spec: CI coverage across the supported Moodle version matrix
+
+Status: accepted
+Tracking issue: #72
+Background: PR #149 (moosh broken on the Moodle 5.1+ `public/` layout)
+
+## Problem statement
+
+CI only builds and tests a single Moodle version (`main`) against PostgreSQL,
+MariaDB and SQLite, and the only functional assertion is that the site returns
+an HTTP homepage. This has two gaps:
+
+1. **No cross-version coverage.** A change can pass CI on `main` while silently
+   breaking a currently supported release. Moodle 4.5 is the current
+   LTS/security-supported branch and 5.3 (represented today by `main`) is the
+   next LTS, so both the legacy and the new layout must be exercised on every
+   build.
+
+2. **HTTP-only assertions miss CLI/bootstrap regressions.** Moodle 5.1 moved the
+   web-accessible code root (including `version.php`) into a `public/`
+   subdirectory. That layout change already broke `moosh`: the wrapper pointed
+   at `/var/www/html`, where 5.1 has no `version.php`, so `moosh` could not
+   bootstrap Moodle and fell back to listing only its global/no-bootstrap
+   commands. When such a command runs in `POST_CONFIGURE_COMMANDS` the container
+   crash-loops (fixed in PR #149). A homepage check alone does not deterministic­ally
+   prove that a Moodle-context CLI command still works.
+
+## Goals
+
+- Every CI run validates the image against multiple Moodle versions covering
+  **both** the pre-5.1 (legacy) and the 5.1+ (`public/`) layouts.
+- CI verifies, per version, that:
+  - Moodle is reachable over HTTP (site installed and serving), and
+  - a real **Moodle-context** `moosh` command executes successfully (i.e.
+    `moosh` bootstraps Moodle, not just its global command list).
+- Failures clearly identify which Moodle version and database backend failed.
+- The fix from PR #149 cannot silently regress.
+
+## Non-goals
+
+- Full browser/Behat/PHPUnit end-to-end testing of Moodle itself.
+- Testing every patch release or every DB × version combination (see Constraints).
+- Changing the production runtime image behavior.
+
+## Constraints
+
+- The Dockerfile downloads Moodle from `refs/tags/${MOODLE_VERSION}` (or `main`),
+  so version values must be **real git tags**; there is no bare `v4.5` tag.
+  Patch tags are pinned to the latest available at implementation time and
+  refreshed as needed. This is documented, not hidden.
+- SQLite mode depends on out-of-tree patches that only exist for Moodle **5.0+**
+  (see Dockerfile), so SQLite cannot cover 4.5.
+- `moosh` lives only inside the `app` container (it needs the Moodle codebase and
+  DB access), so the Moodle-context `moosh` check must run **inside `app`**, not
+  in the black-box `sut` probe container.
+- Cost control: a full 5-versions × 3-databases matrix is wasteful. PostgreSQL
+  (the default backend) covers all versions; MariaDB and SQLite cover a smaller
+  representative subset that still spans both layouts.
+- Keep workflow logic DRY: the up/wait/assert/teardown logic lives in one shared
+  script used by both the release build and the version matrix.
+
+## Version matrix (pinned at implementation time)
+
+| Moodle    | Layout        | PostgreSQL | MariaDB | SQLite |
+|-----------|---------------|:----------:|:-------:|:------:|
+| v4.5.12   | legacy        | ✅         | ✅      | —¹     |
+| v5.0.8    | legacy        | ✅         | —       | ✅     |
+| v5.1.5    | public/       | ✅         | —       | —      |
+| v5.2.1    | public/       | ✅         | ✅      | —      |
+| main (5.3-dev) | public/  | ✅         | —       | ✅     |
+
+¹ SQLite patches exist only for Moodle 5.0+; 4.5 has no SQLite support.
+
+- PostgreSQL: all five versions (legacy + public/ coverage).
+- MariaDB: v4.5.12 (legacy) + v5.2.1 (public/) — one of each layout.
+- SQLite: v5.0.8 (legacy, has patch) + main (public/) — one of each layout.
+
+Latest tags at implementation time: v4.5.12, v5.0.8, v5.1.5, v5.2.1.
+
+## Acceptance criteria
+
+- [ ] CI runs a matrix that builds & tests Moodle 4.5, 5.0, 5.1, 5.2 and main.
+- [ ] The matrix passes the selected `MOODLE_VERSION` into the Docker build.
+- [ ] Each job asserts Moodle is reachable over HTTP.
+- [ ] Each job asserts a Moodle-context `moosh` command succeeds and does **not**
+      fall back to the global/no-bootstrap command list.
+- [ ] The moosh assertion covers both the legacy and the `public/` layout, so a
+      PR #149-style regression fails CI.
+- [ ] Job names identify the Moodle version and database backend.
+- [ ] On failure the logs include container logs, the failing `moosh` output and
+      the Moodle version used.
+
+## Test strategy
+
+- **HTTP readiness / web check** — unchanged responsibility of `run_tests.sh`
+  running in the black-box `sut` container: wait for the port, then assert an
+  HTTP 200 homepage carrying stable Moodle markers.
+- **Moodle-context `moosh` smoke test** — a new `moosh` mode in `run_tests.sh`,
+  executed **inside the `app` container**. It runs `moosh role-list` (a command
+  that requires a bootstrapped Moodle + DB), and fails if:
+  - `moosh` exits non-zero, or
+  - the output shows the global/no-bootstrap fallback
+    (`No command provided … possible commands in current context`), or
+  - the output lacks the standard Moodle roles.
+  `role-list` is chosen because it is the exact command PR #149 used to
+  reproduce the regression, is read-only/deterministic, and works across
+  4.5 → main.
+- **Orchestration** — `tests/compose-test.sh <compose-file>` brings the stack up,
+  waits for the `sut` HTTP check, runs the `moosh` mode inside `app`, dumps
+  container logs on failure and tears the stack down. Reused by `build.yml`
+  (release build) and `moodle-matrix-tests.yml` (version matrix).
+
+## Validation performed
+
+Documented in the PR: at least one legacy-layout version and one `public/`-layout
+version are built and tested locally; anything not runnable locally is called out.

--- a/specs/ci-moodle-version-matrix.md
+++ b/specs/ci-moodle-version-matrix.md
@@ -48,8 +48,16 @@ an HTTP homepage. This has two gaps:
   so version values must be **real git tags**; there is no bare `v4.5` tag.
   Patch tags are pinned to the latest available at implementation time and
   refreshed as needed. This is documented, not hidden.
-- SQLite mode depends on out-of-tree patches that only exist for Moodle **5.0+**
-  (see Dockerfile), so SQLite cannot cover 4.5.
+- SQLite mode depends on out-of-tree patches (`ateeducacion/moodle`: PR #1 for
+  main/v5.2.x, PR #2 for v5.1.x, PR #3 for v5.0.x; see Dockerfile). Only **PR #1
+  (main + v5.2.x) yields a working install**. The CI matrix surfaced that
+  SQLite on **v5.0.8 (PR #3)** and **v5.1.5 (PR #2)** fails in
+  `install_database.php` with *"Error reading environment data"* (reproduced
+  locally on arm64 and in CI on amd64), while PostgreSQL on those same versions
+  passes — so it is the patch, not the layout or this change. 4.5 has no SQLite
+  patch at all. **SQLite therefore only covers v5.2.x + main.** These exclusions
+  are documented here and in the workflow, not silently dropped; fixing the 5.0
+  and 5.1 SQLite patches is out of scope.
 - `moosh` lives only inside the `app` container (it needs the Moodle codebase and
   DB access), so the Moodle-context `moosh` check must run **inside `app`**, not
   in the black-box `sut` probe container.
@@ -64,16 +72,19 @@ an HTTP homepage. This has two gaps:
 | Moodle    | Layout        | PostgreSQL | MariaDB | SQLite |
 |-----------|---------------|:----------:|:-------:|:------:|
 | v4.5.12   | legacy        | ✅         | ✅      | —¹     |
-| v5.0.8    | legacy        | ✅         | —       | ✅     |
-| v5.1.5    | public/       | ✅         | —       | —      |
-| v5.2.1    | public/       | ✅         | ✅      | —      |
+| v5.0.8    | legacy        | ✅         | —       | —²     |
+| v5.1.5    | public/       | ✅         | —       | —²     |
+| v5.2.1    | public/       | ✅         | ✅      | ✅     |
 | main (5.3-dev) | public/  | ✅         | —       | ✅     |
 
-¹ SQLite patches exist only for Moodle 5.0+; 4.5 has no SQLite support.
+¹ 4.5 has no SQLite patch at all.
+² The 5.0 (PR #3) and 5.1 (PR #2) SQLite patches do not yield a working install
+  (see Constraints); excluded.
 
 - PostgreSQL: all five versions (legacy + public/ coverage).
 - MariaDB: v4.5.12 (legacy) + v5.2.1 (public/) — one of each layout.
-- SQLite: v5.0.8 (legacy, has patch) + main (public/) — one of each layout.
+- SQLite: v5.2.1 + main — the versions whose SQLite patch (PR #1) actually
+  installs. Other versions' SQLite is not viable (see Constraints).
 
 Latest tags at implementation time: v4.5.12, v5.0.8, v5.1.5, v5.2.1.
 

--- a/tests/compose-test.sh
+++ b/tests/compose-test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# tests/compose-test.sh <compose-file>
+#
+# Orchestrates one Moodle image test run for a given docker-compose test file:
+#
+#   1. Builds + starts the stack (app, its DB/redis deps and the `sut` probe).
+#   2. Black-box HTTP web check: waits for the `sut` container (which runs
+#      run_tests.sh) and takes its exit code as the readiness/HTTP/SQLite result.
+#   3. Moodle-context moosh smoke test: runs `run_tests.sh moosh` INSIDE the
+#      running `app` container (moosh needs the Moodle codebase + DB).
+#
+# The stack is always torn down; on any failure the container logs, the failing
+# moosh output and the Moodle version are dumped for debugging.
+#
+# The Moodle version comes from $MOODLE_VERSION (default: main) and is injected
+# into the Docker build via the compose files' ${MOODLE_VERSION:-main} build arg.
+set -euo pipefail
+
+FILE="${1:?usage: tests/compose-test.sh <compose-file>}"
+export MOODLE_VERSION="${MOODLE_VERSION:-main}"
+
+dc() { docker compose --file "$FILE" "$@"; }
+
+dump_logs() {
+  echo "::group::Diagnostics for ${FILE} (MOODLE_VERSION=${MOODLE_VERSION})"
+  echo "----- docker compose ps -----"
+  dc ps || true
+  echo "----- app logs -----"
+  dc logs --no-color app || true
+  echo "----- sut logs -----"
+  dc logs --no-color sut || true
+  echo "::endgroup::"
+}
+
+teardown() {
+  dc down --volumes --remove-orphans >/dev/null 2>&1 || true
+}
+trap teardown EXIT
+
+echo "=============================================================="
+echo " Moodle test: version=${MOODLE_VERSION}  compose=${FILE}"
+echo "=============================================================="
+
+# Build + start the whole stack detached so the app container stays up for the
+# moosh check after the sut probe has finished.
+if ! dc up --detach --build; then
+  echo "ERROR: 'docker compose up' failed for ${FILE} (MOODLE_VERSION=${MOODLE_VERSION})."
+  dump_logs
+  exit 1
+fi
+
+# 1) Black-box HTTP web check: wait for the sut container to exit and use its
+#    exit code as the result of run_tests.sh (readiness + HTTP + SQLite file).
+sut_cid="$(dc ps --all --quiet sut)"
+if [ -z "${sut_cid}" ]; then
+  echo "ERROR: could not resolve the sut container id."
+  dump_logs
+  exit 1
+fi
+
+echo ">> Waiting for the HTTP web check (sut) to finish..."
+sut_rc="$(docker wait "${sut_cid}")"
+dc logs --no-color sut || true
+if [ "${sut_rc}" != "0" ]; then
+  echo "ERROR: HTTP web check failed (sut exit ${sut_rc}) for Moodle ${MOODLE_VERSION}."
+  dump_logs
+  exit 1
+fi
+echo ">> HTTP web check passed for Moodle ${MOODLE_VERSION}."
+
+# 2) Moodle-context moosh smoke test, executed inside the running app container.
+echo ">> Running the Moodle-context moosh smoke test inside app..."
+if ! dc exec -T -e MOODLE_VERSION="${MOODLE_VERSION}" app sh /tmp/run_tests.sh moosh; then
+  echo "ERROR: moosh smoke test failed for Moodle ${MOODLE_VERSION} (${FILE})."
+  dump_logs
+  exit 1
+fi
+
+echo ">> All checks passed for Moodle ${MOODLE_VERSION} (${FILE})."


### PR DESCRIPTION
## Summary

CI now builds and tests the image across the **supported Moodle version matrix** instead of only `main`, and every build additionally proves that a **Moodle-context `moosh` command works** — not just that the site returns an HTTP homepage.

Changes:

- **New workflow `moodle-matrix-tests.yml`** — builds & tests Moodle **4.5, 5.0, 5.1, 5.2 and `main`**, injecting the selected `MOODLE_VERSION` into the Docker build. Covers both the legacy and the 5.1+ `public/` layout.
- **New `run_tests.sh moosh` mode** — a Moodle-context `moosh` smoke test (`moosh role-list`) that fails if `moosh` only exposes its global/no-bootstrap commands. Runs inside the `app` container (where the Moodle codebase + DB live). The existing readiness/HTTP web checks are unchanged.
- **Shared orchestrator `tests/compose-test.sh`** — brings the stack up, runs the black-box HTTP check (`sut`), then the moosh smoke test inside `app`, dumps container logs + `moosh` output + the Moodle version on failure, and tears down. Reused by both `build.yml` and the new matrix workflow (no duplicated logic).
- **Compose test files** — `MOODLE_VERSION` is now parametrized (`${MOODLE_VERSION:-main}`) so the matrix can select a version; `run_tests.sh` is mounted into `app` so the moosh check can run in-container (and can be run manually).
- **`build.yml`** — the three test steps now call the shared orchestrator (gaining the moosh check); on pull requests the matrix workflow owns functional coverage, so `build.yml` runs them on push/dispatch as a release smoke test.
- **SDD spec** — `specs/ci-moodle-version-matrix.md` (problem statement, constraints, acceptance criteria, test strategy).

## Why this is needed

CI only tested `main` with an HTTP-only assertion, so it could not catch:

1. **Version-specific regressions** — a change passing on `main` while breaking a supported release.
2. **Layout-specific regressions** — Moodle 5.1 moved the web-accessible code root (incl. `version.php`) into `public/`. That layout change already broke `moosh` (fixed in #149): the wrapper targeted `/var/www/html`, where 5.1 has no `version.php`, so `moosh` fell back to listing only its global commands and — via `POST_CONFIGURE_COMMANDS` — crash-looped the container. An HTTP homepage check cannot prove a Moodle-context CLI command still works, and nothing in CI exercised the `public/` layout.

## Moodle versions covered

| Moodle    | Layout   | PostgreSQL | MariaDB | SQLite |
|-----------|----------|:----------:|:-------:|:------:|
| v4.5.12   | legacy   | ✅ | ✅ | — |
| v5.0.8    | legacy   | ✅ | —  | —¹ |
| v5.1.5    | public/  | ✅ | —  | —¹ |
| v5.2.1    | public/  | ✅ | ✅ | ✅ |
| main (5.3-dev) | public/ | ✅ | — | ✅ |

¹ See "A note on SQLite support" below.

Cost control (per the issue): **PostgreSQL** (the default backend) covers **all** versions; **MariaDB** and **SQLite** cover a smaller representative subset. MariaDB spans both layouts (4.5 legacy + 5.2 public/); SQLite covers the versions whose experimental patch actually installs (v5.2.1 + main). Job names include the Moodle version and DB backend, so a failure identifies exactly what broke.

### A note on SQLite support

Bringing up the matrix surfaced a **pre-existing** limitation: the image's experimental SQLite support only produces a working install on **v5.2.x and `main`** (`ateeducacion/moodle` PR #1). On **v5.0.8** (PR #3) and **v5.1.5** (PR #2), `install_database.php` fails with *"Error reading environment data"* — reproduced locally on arm64 and in CI on amd64 — while **PostgreSQL on those same versions passes**, so it's the patch, not the layout or this change. 4.5 has no SQLite patch at all. SQLite coverage is therefore limited to the versions where it works, and the others are excluded (documented in the workflow + spec, not silently dropped). Fixing the 5.0/5.1 SQLite patches is out of scope here — worth a separate follow-up (fix the patches or scope SQLite support to 5.2+/main).

Version tags are pinned to the latest available patch releases at implementation time (v4.5.12, v5.0.8, v5.1.5, v5.2.1) because the Dockerfile downloads `refs/tags/${MOODLE_VERSION}` and there is no bare `vX.Y` tag; they can be bumped as new patches ship.

## What is tested

Per version × backend:

1. **Moodle loads over HTTP** — the `sut` probe waits for the port and asserts an HTTP 200 homepage with stable Moodle markers (SQLite runs additionally verify the DB file).
2. **Moodle-context `moosh` works** — `moosh role-list` runs inside `app` and must exit 0, must **not** return the global/no-bootstrap fallback (`No command provided … possible commands in current context`), and must list the standard Moodle roles. This directly guards against the #149 regression on both layouts.

## Validation performed

Run locally with Docker 29.5.3 / Compose v5.1.4, plus the full CI matrix on this PR:

- ✅ **`public/` layout — Moodle v5.1.5 + PostgreSQL** (the exact version #149 fixed): HTTP check passed; `moosh role-list` ran in Moodle context (rc=0), correctly detected the `public/` code root, and listed the standard roles. End-to-end exit 0.
- ✅ **legacy layout — Moodle v4.5.12 + PostgreSQL** (current LTS): HTTP check passed; `moosh role-list` ran via the legacy `/var/www/html` path and listed the standard roles. End-to-end exit 0.
- ✅ **`public/` + SQLite — Moodle main and v5.2.1**: HTTP + SQLite-file checks passed; `moosh role-list` (rc=0) works on the SQLite backend.
- ✅ **Regression-detection logic** unit-tested: the assertion fails on the #149 global-only fallback output and on empty output, and passes on healthy `role-list` output.
- ✅ **Reproduced the SQLite limitation** locally (v5.0.8 and v5.1.5 both fail `install_database.php`) to justify their exclusion (see note above).
- ✅ `shellcheck` clean (`run_tests.sh` as POSIX sh, `tests/compose-test.sh` as bash); `docker compose config` valid for all three test files; all workflow YAML parses.
- ✅ **Full CI matrix green** on this PR (PostgreSQL ×5, MariaDB ×2, SQLite ×2) after excluding the non-viable 5.0 SQLite cell.

## References

- Closes #72
- Background: #149 — moosh broken on Moodle 5.1+ (`public/` code root)
