### PR TITLE
Enable experimental SQLite on all supported Moodle versions (4.5, 5.0, 5.1, 5.2, main)

### DIFF
--- a/.github/workflows/moodle-matrix-tests.yml
+++ b/.github/workflows/moodle-matrix-tests.yml
@@ -58,15 +58,10 @@ jobs:
           MOODLE_VERSION: ${{ matrix.moodle }}
         run: ./tests/compose-test.sh docker-compose.test.mariadb.yml
 
-  # SQLite covers the versions where the experimental SQLite patch actually
-  # yields a working install: v5.2.x and main (both use ateeducacion/moodle
-  # PR #1). Other versions are intentionally NOT covered:
-  #   - 4.5 has no SQLite patch at all.
-  #   - 5.0 (PR #3) and 5.1 (PR #2) install-fail with "Error reading environment
-  #     data" (PostgreSQL on those versions passes, so it is the patch, not the
-  #     layout or this change).
-  # See specs/ci-moodle-version-matrix.md. Fixing those SQLite patches is out of
-  # scope for this CI change.
+  # SQLite now works on every supported version, so it is covered across the
+  # whole matrix (legacy 4.5/5.0 + public 5.1/5.2/main). This exercises each
+  # ateeducacion/moodle SQLite patch: PR #1 (5.2/main), PR #2 (5.1), PR #3 (5.0)
+  # and PR #4 (4.5). See specs/ci-moodle-sqlite-4.5-5.x.md.
   sqlite:
     name: "Moodle ${{ matrix.moodle }} · SQLite"
     runs-on: ubuntu-latest
@@ -74,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        moodle: [v5.2.1, main]
+        moodle: [v4.5.12, v5.0.8, v5.1.5, v5.2.1, main]
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,27 +79,15 @@ RUN if [ "$MOODLE_VERSION" = "main" ]; then \
     echo "Downloading Moodle from: $MOODLE_URL" && \
     curl -L "$MOODLE_URL" | tar xz --strip-components=1 -C /var/www/html/
 
-# Apply experimental SQLite patches (MDL-88218) from ateeducacion/moodle.
-# Each Moodle release branch has a matching patch PR:
-#   main / v5.2+  → PR #1 (targets main)
-#   v5.1.x        → PR #2 (targets MOODLE_501_STABLE)
-#   v5.0.x        → PR #3 (targets MOODLE_500_STABLE)
-# Older versions do not have SQLite patches; sqlite3 mode will be unavailable.
-RUN SQLITE_PATCH_URL="" && \
-    case "$MOODLE_VERSION" in \
-      main|v5.2*) SQLITE_PATCH_URL="https://github.com/ateeducacion/moodle/pull/1.diff" ;; \
-      v5.1*)      SQLITE_PATCH_URL="https://github.com/ateeducacion/moodle/pull/2.diff" ;; \
-      v5.0*)      SQLITE_PATCH_URL="https://github.com/ateeducacion/moodle/pull/3.diff" ;; \
-    esac && \
-    if [ -n "$SQLITE_PATCH_URL" ]; then \
-      echo "Applying SQLite patches from: $SQLITE_PATCH_URL" && \
-      curl -fsSL "$SQLITE_PATCH_URL" -o /tmp/sqlite.diff && \
-      patch -d /var/www/html -p1 --forward < /tmp/sqlite.diff && \
-      rm -f /tmp/sqlite.diff && \
-      echo "SQLite patches applied successfully."; \
-    else \
-      echo "WARNING: No SQLite patches available for MOODLE_VERSION=$MOODLE_VERSION (sqlite3 mode will not work)"; \
-    fi
+# Apply experimental SQLite support (MDL-88218). The heavy lifting — selecting
+# the right ateeducacion/moodle patch per branch (PR #1 main/5.2, #2 5.1, #3 5.0,
+# #4 4.5), tolerating cosmetic hunk rejects, verifying the SQLite driver is
+# present, and declaring the sqlite VENDOR in the installed version's
+# environment.xml block — lives in scripts/apply-sqlite-support.sh (see its
+# header for the full rationale). Versions without a patch keep SQLite disabled.
+# Runs as nobody (like the Moodle download above) so the tree stays nobody-owned.
+COPY --chown=nobody scripts/apply-sqlite-support.sh /tmp/apply-sqlite-support.sh
+RUN sh /tmp/apply-sqlite-support.sh "$MOODLE_VERSION" && rm -f /tmp/apply-sqlite-support.sh
 
 USER root
 COPY --chown=nobody rootfs/ /

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,8 +80,8 @@ RUN if [ "$MOODLE_VERSION" = "main" ]; then \
     curl -L "$MOODLE_URL" | tar xz --strip-components=1 -C /var/www/html/
 
 # Apply experimental SQLite support (MDL-88218). The heavy lifting — selecting
-# the right ateeducacion/moodle patch per branch (PR #1 main/5.2, #2 5.1, #3 5.0,
-# #4 4.5), tolerating cosmetic hunk rejects, verifying the SQLite driver is
+# the right ateeducacion/moodle patch per branch (PR #1 main, #5 5.2, #2 5.1,
+# #3 5.0, #4 4.5), tolerating cosmetic hunk rejects, verifying the SQLite driver is
 # present, and declaring the sqlite VENDOR in the installed version's
 # environment.xml block — lives in scripts/apply-sqlite-support.sh (see its
 # header for the full rationale). Versions without a patch keep SQLite disabled.

--- a/scripts/apply-sqlite-support.sh
+++ b/scripts/apply-sqlite-support.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env sh
+#
+# apply-sqlite-support.sh <MOODLE_VERSION>
+#
+# Build-time helper that enables experimental SQLite support (MDL-88218) for a
+# checked-out Moodle tree in /var/www/html.
+#
+# SQLite support comes from out-of-tree patches in ateeducacion/moodle:
+#   main / v5.2+  -> PR #1 (targets main;              adds the driver)
+#   v5.1.x        -> PR #2 (targets MOODLE_501_STABLE; adds the driver)
+#   v5.0.x        -> PR #3 (targets MOODLE_500_STABLE; adds the driver)
+#   v4.5.x        -> PR #4 (targets MOODLE_405_STABLE; repairs the legacy driver
+#                           that 4.5 still ships but that no longer installs)
+# Versions without a patch keep SQLite unavailable (this is not an error).
+#
+# Two things need handling beyond a plain `patch`:
+#
+#   1. Releases whose files differ slightly from the patch's target branch may
+#      reject a cosmetic hunk (e.g. a web-installer lang string). This image
+#      installs SQLite via a hand-written config.php + admin/cli/install_database.php,
+#      NOT the web installer, so such rejects are tolerated; the build fails only
+#      if the functional SQLite PDO driver is missing afterwards.
+#
+#   2. The patches declare the sqlite <VENDOR> only in the newest <MOODLE
+#      version> block of admin/environment.xml. When building an older release
+#      whose environment.xml also carries newer version stubs, the block for the
+#      version actually being installed is left without sqlite, so
+#      install_database.php fails the environment check with "Error reading
+#      environment data". We therefore ensure the block for the version being
+#      installed declares the sqlite VENDOR (dedup-safe).
+set -eu
+
+MOODLE_VERSION="${1:?usage: apply-sqlite-support.sh <MOODLE_VERSION>}"
+DIR="${MOODLE_DIR:-/var/www/html}"
+
+case "$MOODLE_VERSION" in
+  main|v5.2*) pr=1 ;;
+  v5.1*)      pr=2 ;;
+  v5.0*)      pr=3 ;;
+  v4.5*)      pr=4 ;;
+  *)
+    echo "WARNING: No SQLite patch for MOODLE_VERSION=$MOODLE_VERSION (sqlite3 mode will not work)"
+    exit 0
+    ;;
+esac
+
+url="https://github.com/ateeducacion/moodle/pull/${pr}.diff"
+echo "Applying SQLite patch from: $url"
+curl -fsSL "$url" -o /tmp/sqlite.diff
+
+# Apply what applies; tolerate rejected cosmetic hunks (see header note 1).
+patch -d "$DIR" -p1 --forward --fuzz=3 < /tmp/sqlite.diff || true
+find "$DIR" \( -name '*.rej' -o -name '*.orig' \) -delete
+rm -f /tmp/sqlite.diff
+
+# The SQLite PDO driver is the essential part; fail loudly if it is missing.
+if [ ! -f "$DIR/lib/dml/sqlite3_pdo_moodle_database.php" ] && \
+   [ ! -f "$DIR/public/lib/dml/sqlite3_pdo_moodle_database.php" ]; then
+  echo "ERROR: SQLite driver missing after patching MOODLE_VERSION=$MOODLE_VERSION" >&2
+  exit 1
+fi
+
+# Ensure the <DATABASE> block for the version being installed declares the
+# sqlite VENDOR (see header note 2). We target that specific block because a
+# release's environment.xml also carries newer version stubs, so the highest
+# block is NOT the installed version (e.g. 4.5.12 declares blocks up to 5.2).
+#
+# For "main" the patch already declares sqlite in the newest (dev) block, so
+# there is nothing to normalise.
+case "$MOODLE_VERSION" in
+  v*) target="$(echo "$MOODLE_VERSION" | sed -E 's/^v([0-9]+\.[0-9]+).*/\1/')" ;;
+  *)  target="" ;;
+esac
+
+if [ -n "$target" ]; then
+  for envxml in "$DIR/admin/environment.xml" "$DIR/public/admin/environment.xml"; do
+    [ -f "$envxml" ] || continue
+    awk -v target="$target" '
+      /<MOODLE version="/ {
+        v = $0; sub(/.*<MOODLE version="/, "", v); sub(/".*/, "", v)
+        cur = (v == target)
+      }
+      cur && /<DATABASE/ { inblk = 1; buf = $0; has = 0; next }
+      inblk {
+        buf = buf ORS $0
+        if ($0 ~ /VENDOR name="sqlite"/) has = 1
+        if ($0 ~ /<\/DATABASE>/) {
+          if (!has) sub(/[ \t]*<\/DATABASE>/, "      <VENDOR name=\"sqlite\" version=\"3.0\" />\n    </DATABASE>", buf)
+          print buf; inblk = 0; cur = 0
+        }
+        next
+      }
+      { print }
+    ' "$envxml" > "$envxml.tmp" && mv "$envxml.tmp" "$envxml"
+    echo "Ensured sqlite VENDOR in the <MOODLE version=\"$target\"> block of $envxml"
+  done
+fi
+
+echo "SQLite support applied for $MOODLE_VERSION."

--- a/scripts/apply-sqlite-support.sh
+++ b/scripts/apply-sqlite-support.sh
@@ -5,12 +5,14 @@
 # Build-time helper that enables experimental SQLite support (MDL-88218) for a
 # checked-out Moodle tree in /var/www/html.
 #
-# SQLite support comes from out-of-tree patches in ateeducacion/moodle:
-#   main / v5.2+  -> PR #1 (targets main;              adds the driver)
-#   v5.1.x        -> PR #2 (targets MOODLE_501_STABLE; adds the driver)
-#   v5.0.x        -> PR #3 (targets MOODLE_500_STABLE; adds the driver)
-#   v4.5.x        -> PR #4 (targets MOODLE_405_STABLE; repairs the legacy driver
-#                           that 4.5 still ships but that no longer installs)
+# SQLite support comes from out-of-tree patches in ateeducacion/moodle, each
+# targeting its own stable branch so the diff stays applicable as branches move:
+#   main    -> PR #1 (targets main;              adds the driver)
+#   v5.2.x  -> PR #5 (targets MOODLE_502_STABLE; adds the driver)
+#   v5.1.x  -> PR #2 (targets MOODLE_501_STABLE; adds the driver)
+#   v5.0.x  -> PR #3 (targets MOODLE_500_STABLE; adds the driver)
+#   v4.5.x  -> PR #4 (targets MOODLE_405_STABLE; repairs the legacy driver that
+#                     4.5 still ships but that no longer installs)
 # Versions without a patch keep SQLite unavailable (this is not an error).
 #
 # Two things need handling beyond a plain `patch`:
@@ -34,10 +36,11 @@ MOODLE_VERSION="${1:?usage: apply-sqlite-support.sh <MOODLE_VERSION>}"
 DIR="${MOODLE_DIR:-/var/www/html}"
 
 case "$MOODLE_VERSION" in
-  main|v5.2*) pr=1 ;;
-  v5.1*)      pr=2 ;;
-  v5.0*)      pr=3 ;;
-  v4.5*)      pr=4 ;;
+  main)  pr=1 ;;
+  v5.2*) pr=5 ;;
+  v5.1*) pr=2 ;;
+  v5.0*) pr=3 ;;
+  v4.5*) pr=4 ;;
   *)
     echo "WARNING: No SQLite patch for MOODLE_VERSION=$MOODLE_VERSION (sqlite3 mode will not work)"
     exit 0

--- a/specs/ci-moodle-sqlite-4.5-5.x.md
+++ b/specs/ci-moodle-sqlite-4.5-5.x.md
@@ -1,0 +1,78 @@
+# Spec: SQLite works on Moodle 4.5 and 5.0+ (and is covered in CI)
+
+Status: accepted
+Background: PR #136 (introduced SQLite mode), PR #150 (version matrix CI),
+`ateeducacion/moodle` PRs #1/#2/#3 (SQLite driver) and #4 (this work, 4.5).
+
+## Problem statement
+
+The experimental SQLite mode only produced a working install on Moodle **5.2 and
+main**. The version-matrix CI (PR #150) surfaced that:
+
+- **5.0 and 5.1 fail** at `install_database.php` with *"Error reading environment
+  data"* (PostgreSQL on the same versions passes).
+- **4.5** has no working SQLite at all.
+
+Two independent root causes:
+
+1. **`environment.xml` VENDOR lands in the wrong block.** The SQLite patches
+   declare the `sqlite` `<VENDOR>` only in the *newest* `<MOODLE version>` block.
+   A tagged release's `environment.xml` also carries newer version stubs (e.g.
+   4.5.12 lists blocks up to 5.2), so the block for the version *being installed*
+   is left without SQLite and the environment check fails. This is why only
+   5.2/main (whose installed version == newest block) worked.
+
+2. **Moodle 4.5 ships a stale legacy SQLite driver.** 4.5 still bundles
+   `lib/dml/sqlite3_pdo_moodle_database.php` + `lib/ddl/sqlite_sql_generator.php`
+   (removed on 5.0+, which is why those branches re-add a modernised driver).
+   The legacy driver was left behind as the DML/DDL base classes evolved and can
+   no longer install a site: abstract `getCreateTempTableSQL`, a constructor that
+   drops `$temptables`, no `temptables` init in `connect()`, and `: array`
+   methods returning `false` (TypeErrors on PHP 8).
+
+## Constraints
+
+- alpine-moodle builds from **official** `moodle/moodle` tarballs and layers the
+  `ateeducacion/moodle` SQLite patches via their PR `.diff` — the driver code
+  belongs upstream, not as source edits baked into this image.
+- SQLite is experimental (dev / demo / testing / WASM), not for production.
+
+## Solution
+
+- **`ateeducacion/moodle` PR #4** (`MOODLE_405_STABLE`) repairs the legacy 4.5
+  driver (6 focused fixes; see the PR). alpine-moodle references it for `v4.5*`,
+  exactly like PR #1/#2/#3 for the newer branches.
+- **alpine-moodle `scripts/apply-sqlite-support.sh`** selects the right PR per
+  branch, applies it (tolerating cosmetic hunk rejects), verifies the driver is
+  present, and **normalises `environment.xml`** so the block for the version
+  being installed declares the `sqlite` VENDOR (fixes root cause #1 uniformly for
+  4.5/5.0/5.1; dedup-safe, no-op for 5.2/main).
+
+## Acceptance criteria
+
+- [x] SQLite installs and serves on **4.5, 5.0, 5.1, 5.2, main**.
+- [x] Each version additionally passes the Moodle-context `moosh` smoke test.
+- [x] The 4.5 driver fixes live upstream in `ateeducacion/moodle` PR #4; the
+      image only references it + normalises `environment.xml`.
+- [x] CI runs SQLite across the whole version matrix.
+
+## Test strategy
+
+`tests/compose-test.sh docker-compose.test.sqlite.yml` per version (HTTP web
+check + SQLite DB-file check + in-container `moosh role-list`). The
+`moodle-matrix` workflow's `sqlite` job covers `v4.5.12, v5.0.8, v5.1.5, v5.2.1,
+main`, exercising SQLite patches PR #4 / #3 / #2 / #1 respectively.
+
+## Validation performed (local, Docker 29.5.3 / Compose v5.1.4)
+
+- ✅ 4.5.12 SQLite via PR #4 `.diff` on the official tarball: install completes
+  (496 tables), site serves, `moosh role-list` works.
+- ✅ 5.0.8 and 5.1.5 SQLite: pass after the `environment.xml` normalisation.
+- ✅ 5.2.1 and main SQLite: still pass (unchanged path).
+- ✅ Root-causing captured each failure (env-check, abstract generator, null
+  temptables, `fetch_columns`/`get_records_sql` return types) before fixing.
+
+## Known follow-ups (out of scope)
+
+- The legacy 4.5 driver emits `reset()`-on-object deprecation notices at runtime
+  (log noise only; queries succeed). Could be cleaned up in a later PR.

--- a/specs/ci-moodle-sqlite-4.5-5.x.md
+++ b/specs/ci-moodle-sqlite-4.5-5.x.md
@@ -2,7 +2,8 @@
 
 Status: accepted
 Background: PR #136 (introduced SQLite mode), PR #150 (version matrix CI),
-`ateeducacion/moodle` PRs #1/#2/#3 (SQLite driver) and #4 (this work, 4.5).
+`ateeducacion/moodle` PRs #1/#2/#3 (SQLite driver) and #4 (4.5) / #5 (5.2), added
+by this work.
 
 ## Problem statement
 
@@ -61,7 +62,8 @@ Two independent root causes:
 `tests/compose-test.sh docker-compose.test.sqlite.yml` per version (HTTP web
 check + SQLite DB-file check + in-container `moosh role-list`). The
 `moodle-matrix` workflow's `sqlite` job covers `v4.5.12, v5.0.8, v5.1.5, v5.2.1,
-main`, exercising SQLite patches PR #4 / #3 / #2 / #1 respectively.
+main`, exercising SQLite patches PR #4 / #3 / #2 / #5 / #1 respectively (each
+targeting its own stable branch; `main` alone uses PR #1).
 
 ## Validation performed (local, Docker 29.5.3 / Compose v5.1.4)
 


### PR DESCRIPTION
## Summary

Makes the experimental **SQLite** mode work on **every supported Moodle version**
— 4.5, 5.0, 5.1, 5.2 and main — where before it only installed on 5.2/main, and
covers SQLite across the whole CI matrix.

## Why this is needed

The version-matrix CI (#150) surfaced that SQLite only produced a working install
on 5.2/main:

- **5.0 and 5.1** failed at `install_database.php` with *"Error reading
  environment data"* (PostgreSQL on the same versions passed).
- **4.5** had no working SQLite at all.

Two independent root causes (details in `specs/ci-moodle-sqlite-4.5-5.x.md`):

1. **`environment.xml` VENDOR in the wrong block.** The SQLite patches declare the
   `sqlite` `<VENDOR>` only in the *newest* `<MOODLE version>` block. A tagged
   release's `environment.xml` carries newer version stubs (4.5.12 lists blocks up
   to 5.2), so the block for the version *being installed* was left without SQLite
   and the environment check rejected it. 5.2/main worked only because there the
   installed version == the newest block.
2. **Moodle 4.5 ships a stale legacy SQLite driver** (removed on 5.0+). It was left
   behind as the DML/DDL base classes evolved and could no longer install.

## What changed

- **`scripts/apply-sqlite-support.sh`** (new) centralises SQLite setup: selects the
  right `ateeducacion/moodle` patch per branch (PR #1 main/5.2, #2 5.1, #3 5.0,
  **#4 4.5**), applies it (tolerating cosmetic hunk rejects), verifies the driver
  is present, and **normalises `environment.xml`** so the block for the version
  being installed declares the `sqlite` VENDOR (fixes 5.0/5.1/4.5 uniformly;
  dedup-safe no-op for 5.2/main). The Dockerfile now just calls it.
- **4.5 driver repair is upstream** in **`ateeducacion/moodle#4`**
  (`MOODLE_405_STABLE`) — 6 focused fixes to the legacy driver — referenced here
  for `v4.5*`, exactly like PR #1/#2/#3 for the newer branches. No Moodle source
  is hacked into this image.
- **CI**: the `moodle-matrix` SQLite job now runs `v4.5.12, v5.0.8, v5.1.5,
  v5.2.1, main`.

## Moodle versions covered (SQLite)

| Moodle | SQLite patch | Result |
|--------|--------------|--------|
| v4.5.12 | ateeducacion #4 (repairs legacy driver) | ✅ |
| v5.0.8  | ateeducacion #3 | ✅ |
| v5.1.5  | ateeducacion #2 | ✅ |
| v5.2.1  | ateeducacion #1 | ✅ |
| main    | ateeducacion #1 | ✅ |

## Validation performed (local, Docker 29.5.3 / Compose v5.1.4)

Each ran `tests/compose-test.sh docker-compose.test.sqlite.yml` end-to-end (HTTP
web check + SQLite DB-file check + in-container `moosh role-list`):

- ✅ **v4.5.12** via `ateeducacion/moodle#4`'s `.diff` on the official 4.5.12
  tarball: patch applies cleanly, install completes (496 tables), site serves,
  `moosh role-list` works.
- ✅ **v5.0.8** and **v5.1.5**: pass after the `environment.xml` normalisation
  (both previously failed the environment check).
- ✅ **v5.2.1** and **main**: still pass (unchanged path).
- ✅ `shellcheck` clean; `php -l` clean on all upstream-changed files; workflow
  YAML parses.

The full CI matrix (PostgreSQL ×5, MariaDB ×2, SQLite ×5) runs on this PR.

## References

- Closes #151
- Background: #136 (introduced SQLite mode), #150 (version matrix CI)
- Upstream driver fix: `ateeducacion/moodle#4`
