### PR TITLE
feat: version-aware Moodle code sync for persistent volumes (#103)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,10 @@ jobs:
             echo "version=main" >> $GITHUB_OUTPUT
           fi
 
+      # Fast, docker-free coverage of 010-sync-moodle-code.sh (#103).
+      - name: Unit test (Moodle code sync)
+        run: ./tests/unit/test-sync-moodle-code.sh
+
       # Step 8: Test build (for PRs)
       - name: Debug Build on PR
         if: github.event_name == 'pull_request'
@@ -99,10 +103,10 @@ jobs:
           docker buildx build --load .
 
       # Steps 9x: Functional tests (HTTP web check + Moodle-context moosh smoke
-      # test) via the shared orchestrator tests/compose-test.sh. On pull requests
-      # the dedicated moodle-matrix workflow already runs these across every
-      # supported Moodle version, so here they run only on push/dispatch as a
-      # release smoke test (Moodle main, the default MOODLE_VERSION).
+      # + code-sync regression) via the shared orchestrator tests/compose-test.sh.
+      # On pull requests the dedicated moodle-matrix workflow already runs these
+      # across every supported Moodle version, so here they run only on
+      # push/dispatch as a release smoke test (Moodle main, the default MOODLE_VERSION).
       - name: Test (PostgreSQL)
         if: github.event_name != 'pull_request'
         run: ./tests/compose-test.sh docker-compose.test.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,17 @@ FROM ${ARCH}erseco/alpine-php-webserver:${PHP_WEBSERVER_VERSION}
 LABEL maintainer="Ernesto Serrano <info@ernesto.es>"
 
 USER root
-RUN apk add --no-cache composer patch php83-posix php83-xmlwriter php83-pecl-redis \
+RUN apk add --no-cache composer patch rsync php83-posix php83-xmlwriter php83-pecl-redis \
     php83-ldap php83-pecl-igbinary php83-exif php83-sqlite3 php83-pdo_sqlite \
     # php83-zip provides ZipArchive, used by the Moodle blueprint runner for
     # safe bundle/plugin extraction.
     php83-zip \
     # Remove alpine cache
-    && rm -rf /var/cache/apk/*
+    && rm -rf /var/cache/apk/* \
+    # Immutable Moodle source tree used by 010-sync-moodle-code.sh to refresh
+    # /var/www/html when a named volume holds an older release (#103).
+    && mkdir -p /usr/src/moodle \
+    && chown nobody:nobody /usr/src/moodle
 
 USER nobody
 
@@ -57,6 +61,11 @@ ENV LANG=en_US.UTF-8 \
     MOODLE_MAIL_NOREPLY_ADDRESS=noreply@localhost \
     MOODLE_MAIL_PREFIX=[moodle] \
     AUTO_UPDATE_MOODLE=true \
+    # auto: rsync /usr/src/moodle → /var/www/html when the volume's Moodle
+    # $version differs from the image (or the tree is empty). always/never
+    # override. See docs/upgrading.md and #103.
+    SYNC_MOODLE_CODE=auto \
+    EXTRA_PLUGIN_PATHS= \
     DEBUG=false \
     client_max_body_size=50M \
     post_max_size=50M \
@@ -71,14 +80,16 @@ ENV LANG=en_US.UTF-8 \
 # Example:
 # MOODLE_VERSION=v4.5.3
 #
-# Download and extract Moodle
+# Download and extract Moodle into the immutable source tree, then seed the
+# runtime document root. Runtime upgrades of a persistent moodlehtml volume are
+# handled by rootfs/docker-entrypoint-init.d/010-sync-moodle-code.sh.
 RUN if [ "$MOODLE_VERSION" = "main" ]; then \
       MOODLE_URL="https://github.com/moodle/moodle/archive/main.tar.gz"; \
     else \
       MOODLE_URL="https://github.com/moodle/moodle/tarball/refs/tags/${MOODLE_VERSION}"; \
     fi && \
     echo "Downloading Moodle from: $MOODLE_URL" && \
-    curl -L "$MOODLE_URL" | tar xz --strip-components=1 -C /var/www/html/
+    curl -L "$MOODLE_URL" | tar xz --strip-components=1 -C /usr/src/moodle
 
 # Apply experimental SQLite support (MDL-88218). The heavy lifting — selecting
 # the right ateeducacion/moodle patch per branch (PR #1 main, #5 5.2, #2 5.1,
@@ -88,7 +99,17 @@ RUN if [ "$MOODLE_VERSION" = "main" ]; then \
 # header for the full rationale). Versions without a patch keep SQLite disabled.
 # Runs as nobody (like the Moodle download above) so the tree stays nobody-owned.
 COPY --chown=nobody scripts/apply-sqlite-support.sh /tmp/apply-sqlite-support.sh
-RUN sh /tmp/apply-sqlite-support.sh "$MOODLE_VERSION" && rm -f /tmp/apply-sqlite-support.sh
+RUN MOODLE_DIR=/usr/src/moodle sh /tmp/apply-sqlite-support.sh "$MOODLE_VERSION" \
+    && rm -f /tmp/apply-sqlite-support.sh \
+    # Seed the runtime tree and write the release stamp used by the sync script.
+    # Moodle <5.1 keeps version.php at the tree root; 5.1+ moved it under public/.
+    && cp -a /usr/src/moodle/. /var/www/html/ \
+    && VERSION_PHP=/usr/src/moodle/version.php \
+    && if [ ! -f "$VERSION_PHP" ]; then VERSION_PHP=/usr/src/moodle/public/version.php; fi \
+    && sed -n 's/^[[:space:]]*\$version[[:space:]]*=[[:space:]]*\([0-9][0-9.]*\).*/\1/p' \
+         "$VERSION_PHP" | head -n 1 \
+         > /var/www/html/.alpine-moodle-release \
+    && cp /var/www/html/.alpine-moodle-release /usr/src/moodle/.alpine-moodle-release
 
 USER root
 COPY --chown=nobody rootfs/ /

--- a/README.md
+++ b/README.md
@@ -69,7 +69,37 @@ volumes:
 docker compose up -d
 ```
 
-For production deployments (reverse proxy, TLS, Redis, tuning, upgrades), see the [documentation site](https://erseco.github.io/alpine-moodle/).
+### Upgrading Moodle (important)
+
+`AUTO_UPDATE_MOODLE` only runs the **database** upgrade (`admin/cli/upgrade.php`). The **PHP code** is handled separately:
+
+| Setup | How code upgrades |
+|-------|-------------------|
+| **With `moodlehtml` volume** (example above) | **Automatic.** Default `SYNC_MOODLE_CODE=auto` compares Moodle `$version` in the volume with the image. On mismatch it rsyncs core from `/usr/src/moodle` → `/var/www/html`, keeps `config.php`, restores optional `EXTRA_PLUGIN_PATHS`, then runs `upgrade.php`. |
+| **Without `moodlehtml`** | The container *is* the code — `docker compose pull && up` is enough. Reinstall plugins via `PLUGINS` / Moosh if needed. |
+
+```bash
+# 1. Change the image tag (e.g. v5.0.1 → v5.0.2) in compose
+# 2. Pull and recreate
+docker compose pull
+docker compose up -d
+docker compose logs -f moodle
+# Look for: Moodle code sync: 2025041401.00 → 2025041402.00
+```
+
+Preserve custom plugins that live only on the volume:
+
+```yaml
+environment:
+  SYNC_MOODLE_CODE: auto                    # default — set "never" to freeze the volume tree
+  EXTRA_PLUGIN_PATHS: "mod/attendance theme/space local/mytool"
+  # Or reinstall every boot (recommended when possible):
+  # PLUGINS: "mod_attendance=https://…/attendance.zip"
+```
+
+Full details: [Upgrading](https://erseco.github.io/alpine-moodle/upgrading/) · [Persistence](https://erseco.github.io/alpine-moodle/persistence/) · issue [#103](https://github.com/erseco/alpine-moodle/issues/103).
+
+For production deployments (reverse proxy, TLS, Redis, tuning), see the [documentation site](https://erseco.github.io/alpine-moodle/).
 
 ## Running Commands as Root
 
@@ -248,6 +278,7 @@ See the full guide, resource descriptors, security model and idempotency notes i
 - Multi-arch: `amd64`, `arm64`, `arm/v7`, `arm/v6`, `386`, `ppc64le`, `s390x`
 - [Moosh CLI](https://github.com/tmuras/moosh) bundled for automation
 - Pre/post configuration hooks (`PRE_CONFIGURE_COMMANDS`, `POST_CONFIGURE_COMMANDS`)
+- **Version-aware Moodle code sync** (`SYNC_MOODLE_CODE=auto`) so a persistent `moodlehtml` volume upgrades when you change the image tag — no more `docker volume rm` for core updates ([#103](https://github.com/erseco/alpine-moodle/issues/103))
 - Runs as the non-privileged `nobody` user
 - Logs to `stdout` / `stderr` — just `docker logs -f`
 - Internal cron via `runit` (configurable, or run it externally)

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Define the ENV variables in `docker-compose.yml`. The full reference with notes,
 | `MOODLE_MAIL_NOREPLY_ADDRESS` | `noreply@localhost` | No-reply address. |
 | `MOODLE_MAIL_PREFIX`        | `[moodle]`           | Email subject prefix. |
 | `AUTO_UPDATE_MOODLE`        | `true`               | Set to `false` to skip `admin/cli/upgrade.php` on container start. |
+| `SYNC_MOODLE_CODE`          | `auto`               | Refresh Moodle PHP code from the image into a persistent `moodlehtml` volume when versions differ (`auto` / `always` / `never`). See [upgrading](https://erseco.github.io/alpine-moodle/upgrading/). |
+| `EXTRA_PLUGIN_PATHS`        | *(empty)*            | Space-separated relative paths under `/var/www/html` preserved across a code sync (e.g. `mod/attendance theme/space`). |
 | `DEBUG`                     | `false`              | When `true`, enables Moodle `DEVELOPER` debug level. |
 | `client_max_body_size`      | `50M`                | Nginx max request body size. |
 | `post_max_size`             | `50M`                | PHP `post_max_size`. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -143,6 +143,18 @@ environment:
   RUN_CRON_TASKS: "false"
 ```
 
+## Code sync for persistent `/var/www/html`
+
+When you mount a `moodlehtml` volume, core PHP is still upgradeable by changing the image tag. On start, `SYNC_MOODLE_CODE=auto` (default) may rsync `/usr/src/moodle` → `/var/www/html` if Moodle `$version` differs. `config.php` is always kept; list extra paths in `EXTRA_PLUGIN_PATHS`.
+
+```yaml
+environment:
+  SYNC_MOODLE_CODE: auto
+  EXTRA_PLUGIN_PATHS: "mod/attendance local/mytool"
+```
+
+This is **not** the same as `AUTO_UPDATE_MOODLE` (database schema). Full explanation: [Upgrading](upgrading.md), [Persistence](persistence.md).
+
 ## Test scenario generator
 
 ```bash

--- a/docs/docker-compose.md
+++ b/docs/docker-compose.md
@@ -20,16 +20,21 @@ services:
 
   moodle:
     image: erseco/alpine-moodle
+    # Pin a release for production, e.g. erseco/alpine-moodle:v5.0.2
     restart: unless-stopped
     environment:
       SITE_URL: http://localhost
       MOODLE_USERNAME: admin
       MOODLE_PASSWORD: ChangeMe123!
+      # Default: refresh Moodle PHP core from the image when the volume is on an
+      # older $version (no need to docker volume rm moodlehtml). See Upgrading.
+      # SYNC_MOODLE_CODE: auto
+      # EXTRA_PLUGIN_PATHS: "mod/attendance theme/space"
     ports:
       - "80:8080"
     volumes:
       - moodledata:/var/www/moodledata
-      - moodlehtml:/var/www/html
+      - moodlehtml:/var/www/html   # safe with SYNC_MOODLE_CODE=auto (default)
     depends_on:
       - postgres
 
@@ -38,6 +43,10 @@ volumes:
   moodledata:
   moodlehtml:
 ```
+
+!!! tip "Upgrading this stack"
+    Change the image tag → `docker compose pull && docker compose up -d`.
+    With `moodlehtml` mounted, `SYNC_MOODLE_CODE=auto` (default) rsyncs core from the new image, keeps `config.php`, then runs `upgrade.php`. Details: [Upgrading](upgrading.md).
 
 ## Persistent deployment with Redis
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -93,8 +93,17 @@ See [Reverse Proxy](reverse-proxy.md) for concrete examples.
 | Variable                 | Default | Description |
 |--------------------------|---------|-------------|
 | `AUTO_UPDATE_MOODLE`     | `true`  | If `false`, skip the automatic `admin/cli/upgrade.php` on container start. |
-| `SYNC_MOODLE_CODE`       | `auto`  | How to refresh Moodle **PHP code** from the image into `/var/www/html` when a volume is used. `auto` syncs when the volume is empty or its Moodle `$version` differs from the image; `always` rsyncs every start; `never` leaves the volume untouched (legacy behaviour). See [Upgrading](upgrading.md) and [#103](https://github.com/erseco/alpine-moodle/issues/103). |
+| `SYNC_MOODLE_CODE`       | `auto`  | How to refresh Moodle **PHP code** from the image into `/var/www/html` when a volume is used. **This is independent of `AUTO_UPDATE_MOODLE`** (DB schema). Values: `auto` (default) — sync when the volume is empty or its Moodle `$version` differs from the image; `always` — rsync every start; `never` — leave the volume tree untouched (legacy). See [Upgrading](upgrading.md) and [#103](https://github.com/erseco/alpine-moodle/issues/103). |
 | `EXTRA_PLUGIN_PATHS`     | *(empty)* | Space-separated paths **relative** to `/var/www/html` preserved across a code sync (e.g. `mod/attendance theme/space local/mytool`). Rejects absolute paths and `..`. Prefer `PLUGINS` / Moosh when you can reinstall declaratively. |
+
+### Code sync vs database upgrade
+
+| Knob | What it updates | When |
+|------|-----------------|------|
+| `SYNC_MOODLE_CODE` | PHP files under `/var/www/html` (from `/usr/src/moodle`) | Before install/upgrade CLI runs |
+| `AUTO_UPDATE_MOODLE` | Database schema via `admin/cli/upgrade.php` | After code is in place |
+
+Stamp file written after a successful sync: `/var/www/html/.alpine-moodle-release` (Moodle `$version` id).
 | `RUN_CRON_TASKS`         | `true`  | Set to `false` to disable the internal `runit`-managed cron loop. Useful when you run cron externally. |
 | `DEBUG`                  | `false` | When `true`, enables Moodle `DEVELOPER` debug level and `debugdisplay`. |
 | `PRE_CONFIGURE_COMMANDS` | *(empty)* | Shell commands run **before** Moodle configuration. |

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -93,6 +93,8 @@ See [Reverse Proxy](reverse-proxy.md) for concrete examples.
 | Variable                 | Default | Description |
 |--------------------------|---------|-------------|
 | `AUTO_UPDATE_MOODLE`     | `true`  | If `false`, skip the automatic `admin/cli/upgrade.php` on container start. |
+| `SYNC_MOODLE_CODE`       | `auto`  | How to refresh Moodle **PHP code** from the image into `/var/www/html` when a volume is used. `auto` syncs when the volume is empty or its Moodle `$version` differs from the image; `always` rsyncs every start; `never` leaves the volume untouched (legacy behaviour). See [Upgrading](upgrading.md) and [#103](https://github.com/erseco/alpine-moodle/issues/103). |
+| `EXTRA_PLUGIN_PATHS`     | *(empty)* | Space-separated paths **relative** to `/var/www/html` preserved across a code sync (e.g. `mod/attendance theme/space local/mytool`). Rejects absolute paths and `..`. Prefer `PLUGINS` / Moosh when you can reinstall declaratively. |
 | `RUN_CRON_TASKS`         | `true`  | Set to `false` to disable the internal `runit`-managed cron loop. Useful when you run cron externally. |
 | `DEBUG`                  | `false` | When `true`, enables Moodle `DEVELOPER` debug level and `debugdisplay`. |
 | `PRE_CONFIGURE_COMMANDS` | *(empty)* | Shell commands run **before** Moodle configuration. |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -52,6 +52,10 @@ Yes — set `RUN_CRON_TASKS=false`. You are then responsible for running `admin/
 
 Yes — set `AUTO_UPDATE_MOODLE=false`. The container will start without running `admin/cli/upgrade.php`; you must run it yourself before letting users back in.
 
+## Why didn't changing the image tag upgrade my site?
+
+`AUTO_UPDATE_MOODLE` only runs the **database** upgrade. If `/var/www/html` is a named volume, older images left the PHP tree pinned on the volume ([#102](https://github.com/erseco/alpine-moodle/issues/102)). Current images run a **code sync** first (`SYNC_MOODLE_CODE=auto`): when the volume's Moodle `$version` differs from the image, core is rsynced from `/usr/src/moodle` while `config.php` (and optional `EXTRA_PLUGIN_PATHS`) are preserved, then `upgrade.php` runs. See [Upgrading](upgrading.md).
+
 ## Which architectures are supported?
 
 `amd64`, `arm64`, `arm/v7`, `arm/v6`, `386`, `ppc64le`, `s390x`. Pull `erseco/alpine-moodle` on any of them and Docker will fetch the right variant.

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ Highlights:
 - Works with PostgreSQL, MariaDB/MySQL, or SQLite (single-container dev mode)
 - Optional Redis session handler for HA deployments
 - Supports Moodle **4.x**, **5.0**, **5.1** (with `/public` directory) and `main`
+- **Version-aware code sync** (`SYNC_MOODLE_CODE=auto`) — upgrade Moodle core by changing the image tag even with a persistent `moodlehtml` volume ([Upgrading](upgrading.md), [#103](https://github.com/erseco/alpine-moodle/issues/103))
 - Multi-arch images: `amd64`, `arm64`, `arm/v7`, `arm/v6`, `386`, `ppc64le`, `s390x`
 - Internal cron via `runit` (configurable)
 - Logs go straight to `docker logs`

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -37,28 +37,42 @@ volumes:
 
 ## The `moodlehtml` tradeoff
 
-Mounting `/var/www/html` as a named volume preserves installed plugins, custom themes, and `config.php` between container restarts. **The cost is that upgrading Moodle by changing the image tag alone does not work**, because the old code is kept on the volume ([#102](https://github.com/erseco/alpine-moodle/issues/102), [#103](https://github.com/erseco/alpine-moodle/issues/103)).
+Mounting `/var/www/html` as a named volume preserves `config.php` and any custom plugin/theme files you keep there. Historically the cost was that **changing the image tag alone did not refresh Moodle core**, because the volume kept the old tree ([#102](https://github.com/erseco/alpine-moodle/issues/102), [#103](https://github.com/erseco/alpine-moodle/issues/103)).
 
-You have two patterns:
+Current images ship **version-aware code sync** (`SYNC_MOODLE_CODE=auto` by default): on start, if the volume's Moodle `$version` differs from the image, the container rsyncs the immutable tree at `/usr/src/moodle` into `/var/www/html`, preserves `config.php`, restores any paths listed in `EXTRA_PLUGIN_PATHS`, then runs the usual `upgrade.php` flow.
 
-=== "Persistent `moodlehtml` (default)"
+You still have three patterns:
 
-    Pros: plugins and themes survive restarts, `config.php` keeps customisations.
+=== "Persistent `moodlehtml` + auto sync (recommended with volumes)"
 
-    Cons: to upgrade Moodle you need to remove the `moodlehtml` volume, start the new image, then re-apply plugins/themes. Always back up first.
+    Pros: change the image tag to upgrade core; `config.php` is kept; optional custom paths via `EXTRA_PLUGIN_PATHS`.
+
+    ```yaml
+    services:
+      moodle:
+        image: erseco/alpine-moodle:v5.0.2
+        volumes:
+          - moodledata:/var/www/moodledata
+          - moodlehtml:/var/www/html
+        environment:
+          SYNC_MOODLE_CODE: auto          # default
+          EXTRA_PLUGIN_PATHS: "mod/attendance theme/space"
+          # Prefer declarative installs when possible:
+          # PLUGINS: "mod_attendance=https://…/attendance.zip"
+    ```
 
     ```bash
-    docker compose down
-    docker volume rm <project>_moodlehtml
     docker compose pull
     docker compose up -d
     ```
 
-=== "Ephemeral `moodlehtml`"
+    Set `SYNC_MOODLE_CODE=never` only if you deliberately maintain a patched tree inside the volume and do **not** want image tags to overwrite it.
 
-    Pros: upgrading Moodle is just `docker compose pull && docker compose up -d`.
+=== "Ephemeral `moodlehtml` (no code volume)"
 
-    Cons: you must re-install plugins and re-apply theme customisations on every rebuild, or install them via `POST_CONFIGURE_COMMANDS` on every start.
+    Pros: simplest mental model — the container *is* the code.
+
+    Cons: re-install plugins on every recreate (use `PLUGINS` or Moosh in `POST_CONFIGURE_COMMANDS`).
 
     ```yaml
     services:
@@ -68,17 +82,16 @@ You have two patterns:
           # no moodlehtml volume
     ```
 
-    Pair this with idempotent Moosh commands:
+=== "Manual volume wipe (legacy)"
 
-    ```yaml
-    environment:
-      POST_CONFIGURE_COMMANDS: |
-        moosh plugin-list
-        moosh plugin-install --delete mod_attendance
+    Still works if you prefer a clean tree:
+
+    ```bash
+    docker compose down
+    docker volume rm <project>_moodlehtml
+    docker compose pull
+    docker compose up -d
     ```
-
-!!! info "Future improvement"
-    [#103](https://github.com/erseco/alpine-moodle/issues/103) tracks a finer-grained approach that would persist only `config.php`, themes and modules. Until that lands, pick the pattern that matches your risk tolerance.
 
 ## PostgreSQL 18+ volume path
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -132,22 +132,33 @@ For bind mounts only. Named Docker volumes get the right ownership automatically
 
 ## Plugins disappear after upgrading
 
-**Cause**: The `moodlehtml` volume was removed during the upgrade. Plugins live inside `/var/www/html/...`. Related: [#9](https://github.com/erseco/alpine-moodle/issues/9), [#103](https://github.com/erseco/alpine-moodle/issues/103).
+**Cause**: Either the `moodlehtml` volume was wiped, or a code sync (`SYNC_MOODLE_CODE=auto`) replaced core and a custom plugin path was **not** listed in `EXTRA_PLUGIN_PATHS` / reinstalled via `PLUGINS` or Moosh. Related: [#9](https://github.com/erseco/alpine-moodle/issues/9), [#103](https://github.com/erseco/alpine-moodle/issues/103).
 
-**Fix**: Reinstall via `POST_CONFIGURE_COMMANDS` so they are reapplied automatically:
+**Fix** — prefer declarative reinstall so plugins survive every boot:
 
 ```yaml
 environment:
   POST_CONFIGURE_COMMANDS: |
     moosh plugin-list
     moosh plugin-install --delete mod_attendance
+  # Or list volume-only paths that must survive rsync:
+  # EXTRA_PLUGIN_PATHS: "mod/attendance theme/space"
 ```
 
 ## Upgrade seems to do nothing — "No upgrade needed"
 
-**Cause**: Old Moodle code is still in the `moodlehtml` volume because you changed the image tag without clearing it. Related: [#102](https://github.com/erseco/alpine-moodle/issues/102).
+**Cause**: `AUTO_UPDATE_MOODLE` only runs the **database** upgrade. If the PHP tree on a `moodlehtml` volume is still the old release, Moodle correctly reports that no DB upgrade is needed. Related: [#102](https://github.com/erseco/alpine-moodle/issues/102), [#103](https://github.com/erseco/alpine-moodle/issues/103).
 
-**Fix**: Back up, then remove the `moodlehtml` volume and restart:
+**Current images** ship `SYNC_MOODLE_CODE=auto` (default): on start they compare Moodle `$version` in the volume with the image and rsync core from `/usr/src/moodle` when they differ, then run `upgrade.php`.
+
+**Check**:
+
+```bash
+docker compose logs moodle | grep -E 'Moodle code sync|Upgrading moodle'
+# Expect: Moodle code sync: 2025041401.00 → 2025041402.00
+```
+
+**If you are on an older image** without code sync, either upgrade the image or wipe the code volume once:
 
 ```bash
 docker compose down
@@ -155,6 +166,8 @@ docker volume rm <project>_moodlehtml
 docker compose pull
 docker compose up -d
 ```
+
+**If sync is disabled** (`SYNC_MOODLE_CODE=never`), re-enable `auto` or wipe the volume as above.
 
 See [Upgrading](upgrading.md) for the full procedure.
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -22,43 +22,24 @@ Steps the container takes on start, when an existing installation is detected:
 2. `admin/cli/upgrade.php --non-interactive --allow-unstable`
 3. `admin/cli/maintenance.php --disable`
 
-This covers **database schema** upgrades. It does **not** by itself swap out the Moodle PHP code — that depends on how you handle the `/var/www/html` volume.
+This covers **database schema** upgrades. Replacing the Moodle **PHP code** is handled separately by the version-aware code sync (`SYNC_MOODLE_CODE`, default `auto`) when you use a persistent `moodlehtml` volume ([#103](https://github.com/erseco/alpine-moodle/issues/103)).
 
 ## Upgrading the Moodle code
 
-Your upgrade procedure depends on whether you persist `/var/www/html` as a named volume.
+=== "With `moodlehtml` volume (auto sync)"
 
-=== "Without `moodlehtml` volume"
+    On start, if the volume's Moodle `$version` differs from the image, the container:
 
-    The container replaces the Moodle code on every start. Upgrading is just:
+    1. Preserves `config.php` and any `EXTRA_PLUGIN_PATHS`
+    2. Rsyncs `/usr/src/moodle/` → `/var/www/html/` (`--delete` removes leftover core files)
+    3. Restores the preserved paths
+    4. Writes `.alpine-moodle-release`
+    5. Continues with the usual `AUTO_UPDATE_MOODLE` / `upgrade.php` flow
 
-    ```bash
-    docker compose pull
-    docker compose up -d
-    ```
+    Operator steps:
 
-    Trade-off: plugins and themes must be re-installed on every boot (use `POST_CONFIGURE_COMMANDS` with Moosh).
-
-=== "With `moodlehtml` volume"
-
-    Pinned Moodle code in a persistent volume will **not** be overwritten when you change the image tag ([#102](https://github.com/erseco/alpine-moodle/issues/102)). You will see logs like:
-
-    ```
-    No upgrade needed for the installed version 5.0.1 (Build: 20250609). Thanks for coming anyway!
-    ```
-
-    To actually upgrade:
-
-    1. Back up the database, `moodledata`, and `moodlehtml` (see [Persistence & Volumes](persistence.md)).
-    2. Put the site into maintenance mode (optional but recommended).
-    3. Stop the stack and remove the `moodlehtml` volume:
-
-        ```bash
-        docker compose down
-        docker volume rm <project>_moodlehtml
-        ```
-
-    4. Change the image tag in `docker-compose.yml`:
+    1. Back up the database and `moodledata` (see [Persistence & Volumes](persistence.md)).
+    2. Change the image tag:
 
         ```yaml
         services:
@@ -66,7 +47,7 @@ Your upgrade procedure depends on whether you persist `/var/www/html` as a named
             image: erseco/alpine-moodle:v5.0.2
         ```
 
-    5. Bring it back up:
+    3. Pull and recreate:
 
         ```bash
         docker compose pull
@@ -74,10 +55,41 @@ Your upgrade procedure depends on whether you persist `/var/www/html` as a named
         docker compose logs -f moodle
         ```
 
-    6. Reinstall any custom plugins and themes.
+        Look for a log line like `Moodle code sync: 2025041401.00 → 2025041402.00`.
+
+    Custom plugins that live only on the volume should either be listed in `EXTRA_PLUGIN_PATHS` (e.g. `mod/attendance theme/space`) or reinstalled declaratively via `PLUGINS` / Moosh after each sync.
+
+    To keep today's "volume always wins" behaviour (no automatic core refresh):
+
+    ```yaml
+    environment:
+      SYNC_MOODLE_CODE: "never"
+    ```
+
+=== "Without `moodlehtml` volume"
+
+    The container filesystem *is* the code. Upgrading is just:
+
+    ```bash
+    docker compose pull
+    docker compose up -d
+    ```
+
+    Re-install plugins on every recreate with `PLUGINS` or `POST_CONFIGURE_COMMANDS` + Moosh.
+
+=== "Legacy: wipe `moodlehtml`"
+
+    Still valid if you want a clean tree:
+
+    ```bash
+    docker compose down
+    docker volume rm <project>_moodlehtml
+    docker compose pull
+    docker compose up -d
+    ```
 
 !!! warning "Always back up first"
-    Upgrades that involve removing volumes are irreversible. Take a database dump and a tarball of `moodledata` before you run `docker volume rm`.
+    Take a database dump and a tarball of `moodledata` before major upgrades. Code sync replaces files under `/var/www/html` (except `config.php` and `EXTRA_PLUGIN_PATHS`).
 
 ## Upgrading from Moodle < 5.1 to ≥ 5.1
 

--- a/rootfs/docker-entrypoint-init.d/010-sync-moodle-code.sh
+++ b/rootfs/docker-entrypoint-init.d/010-sync-moodle-code.sh
@@ -1,0 +1,210 @@
+#!/bin/sh
+#
+# 010-sync-moodle-code.sh
+#
+# Version-aware Moodle core sync for persistent /var/www/html volumes (#103).
+#
+# When /var/www/html is a named volume, Docker only seeds it on first use from
+# the image. Later image upgrades (v5.0.1 → v5.0.2) leave the volume on the old
+# tree, so AUTO_UPDATE_MOODLE runs upgrade.php against stale code.
+#
+# This script mirrors the official Moodle upgrade step "replace the code while
+# keeping config.php" by rsyncing the immutable tree baked into the image at
+# /usr/src/moodle into /var/www/html when versions diverge.
+#
+# Environment:
+#   SYNC_MOODLE_CODE      auto|always|never  (default: auto)
+#   EXTRA_PLUGIN_PATHS    space-separated relative paths under html to preserve
+#                         (e.g. "mod/attendance theme/space local/foo")
+#   MOODLE_SRC_DIR        override source tree (default: /usr/src/moodle)
+#   MOODLE_HTML_DIR       override runtime tree (default: /var/www/html)
+#
+# Stamp file written after a successful sync:
+#   $MOODLE_HTML_DIR/.alpine-moodle-release  (Moodle $version id from version.php)
+#
+set -eu
+
+MOODLE_SRC_DIR="${MOODLE_SRC_DIR:-/usr/src/moodle}"
+MOODLE_HTML_DIR="${MOODLE_HTML_DIR:-/var/www/html}"
+STAMP_NAME=".alpine-moodle-release"
+STAMP_FILE="${MOODLE_HTML_DIR}/${STAMP_NAME}"
+SYNC_MODE="${SYNC_MOODLE_CODE:-auto}"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Resolve the path to Moodle's root version.php.
+# Pre-5.1: <root>/version.php
+# 5.1+:    <root>/public/version.php  (web root moved under public/)
+moodle_version_php() {
+  root="$1"
+  if [ -f "${root}/version.php" ]; then
+    printf '%s\n' "${root}/version.php"
+  elif [ -f "${root}/public/version.php" ]; then
+    printf '%s\n' "${root}/public/version.php"
+  fi
+}
+
+# Extract Moodle $version (e.g. 2025041401.00) from a Moodle tree root.
+# Prints empty string if unparseable.
+moodle_version_id() {
+  root="$1"
+  version_php="$(moodle_version_php "$root")"
+  if [ -z "$version_php" ] || [ ! -f "$version_php" ]; then
+    return 0
+  fi
+  # Match: $version  = 2025041401.00;  (allow flexible whitespace)
+  sed -n 's/^[[:space:]]*\$version[[:space:]]*=[[:space:]]*\([0-9][0-9.]*\).*/\1/p' \
+    "$version_php" | head -n 1
+}
+
+moodle_tree_present() {
+  root="$1"
+  if [ -f "${root}/version.php" ] || [ -f "${root}/public/version.php" ] \
+    || [ -f "${root}/lib/moodlelib.php" ] || [ -f "${root}/public/lib/moodlelib.php" ]; then
+    return 0
+  fi
+  return 1
+}
+
+# Validate EXTRA_PLUGIN_PATHS entries: relative, no .., no absolute.
+validate_extra_path() {
+  relpath="$1"
+  case "$relpath" in
+    ""|.*|/*|*..*|*../*|*/../*|*/..)
+      echo "ERROR: invalid EXTRA_PLUGIN_PATHS entry: '$relpath'" >&2
+      echo "       Paths must be relative to the Moodle root (e.g. mod/attendance)." >&2
+      return 1
+      ;;
+  esac
+  return 0
+}
+
+should_sync() {
+  mode="$1"
+  image_ver="$2"
+  volume_ver="$3"
+  html_has_code="$4"
+
+  case "$mode" in
+    never)
+      return 1
+      ;;
+    always)
+      return 0
+      ;;
+    auto|"")
+      # Empty volume / missing code → always seed from the image.
+      if [ "$html_has_code" != "yes" ]; then
+        return 0
+      fi
+      # Missing image version is fatal only if we would sync; handled by caller.
+      if [ -z "$volume_ver" ] || [ "$volume_ver" != "$image_ver" ]; then
+        return 0
+      fi
+      return 1
+      ;;
+    *)
+      echo "ERROR: SYNC_MOODLE_CODE must be auto|always|never (got '$mode')" >&2
+      exit 1
+      ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if [ ! -d "$MOODLE_SRC_DIR" ] || ! moodle_tree_present "$MOODLE_SRC_DIR"; then
+  echo "WARNING: Moodle source tree missing at ${MOODLE_SRC_DIR}; skipping code sync."
+  exit 0
+fi
+
+if ! command -v rsync >/dev/null 2>&1; then
+  echo "ERROR: rsync is required for Moodle code sync but was not found." >&2
+  exit 1
+fi
+
+image_ver="$(moodle_version_id "$MOODLE_SRC_DIR")"
+if [ -z "$image_ver" ]; then
+  echo "ERROR: could not parse \$version from ${MOODLE_SRC_DIR} (version.php)" >&2
+  exit 1
+fi
+
+volume_ver=""
+if [ -f "$STAMP_FILE" ] && [ -s "$STAMP_FILE" ]; then
+  volume_ver="$(tr -d '[:space:]' < "$STAMP_FILE")"
+else
+  volume_ver="$(moodle_version_id "$MOODLE_HTML_DIR")"
+fi
+
+html_has_code="no"
+if moodle_tree_present "$MOODLE_HTML_DIR"; then
+  html_has_code="yes"
+fi
+
+if ! should_sync "$SYNC_MODE" "$image_ver" "$volume_ver" "$html_has_code"; then
+  echo "Moodle code sync: skipped (SYNC_MOODLE_CODE=${SYNC_MODE}, image=${image_ver}, volume=${volume_ver:-<none>})."
+  exit 0
+fi
+
+echo "Moodle code sync: ${volume_ver:-<empty|unknown>} → ${image_ver} (mode=${SYNC_MODE})"
+
+tmpdir="$(mktemp -d)"
+# shellcheck disable=SC2064
+trap 'rm -rf "$tmpdir"' EXIT
+
+# 1) Preserve config.php
+if [ -f "${MOODLE_HTML_DIR}/config.php" ]; then
+  cp -a "${MOODLE_HTML_DIR}/config.php" "${tmpdir}/config.php"
+  echo "  preserved config.php"
+fi
+
+# 2) Preserve EXTRA_PLUGIN_PATHS
+# shellcheck disable=SC2086
+for relpath in ${EXTRA_PLUGIN_PATHS:-}; do
+  validate_extra_path "$relpath"
+  src="${MOODLE_HTML_DIR}/${relpath}"
+  if [ -e "$src" ]; then
+    mkdir -p "${tmpdir}/extra/$(dirname "$relpath")"
+    cp -a "$src" "${tmpdir}/extra/${relpath}"
+    echo "  preserved ${relpath}"
+  else
+    echo "  EXTRA_PLUGIN_PATHS: ${relpath} not present (skip)"
+  fi
+done
+
+# 3) Sync core from the immutable image tree.
+#    --delete removes leftover core files from older releases (required for clean upgrades).
+#    Exclude the stamp and config.php; both are restored/written after.
+mkdir -p "$MOODLE_HTML_DIR"
+# --checksum: do not skip same-size/same-mtime files (matters when a volume
+# was hand-edited or when tests seed trees in the same second).
+rsync -a --delete --checksum \
+  --exclude config.php \
+  --exclude "${STAMP_NAME}" \
+  "${MOODLE_SRC_DIR}/" "${MOODLE_HTML_DIR}/"
+
+# 4) Restore config.php
+if [ -f "${tmpdir}/config.php" ]; then
+  cp -a "${tmpdir}/config.php" "${MOODLE_HTML_DIR}/config.php"
+fi
+
+# 5) Restore extra plugin paths (overwrite whatever the image shipped there)
+if [ -d "${tmpdir}/extra" ]; then
+  # shellcheck disable=SC2086
+  for relpath in ${EXTRA_PLUGIN_PATHS:-}; do
+    if [ -e "${tmpdir}/extra/${relpath}" ]; then
+      mkdir -p "${MOODLE_HTML_DIR}/$(dirname "$relpath")"
+      rm -rf "${MOODLE_HTML_DIR}/${relpath}"
+      cp -a "${tmpdir}/extra/${relpath}" "${MOODLE_HTML_DIR}/${relpath}"
+      echo "  restored ${relpath}"
+    fi
+  done
+fi
+
+# 6) Stamp only after a successful sync
+printf '%s\n' "$image_ver" > "$STAMP_FILE"
+
+echo "Moodle code sync: done (stamp=${image_ver})."

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -14,6 +14,12 @@ set -eu
 #     because moosh needs the Moodle codebase and DB access, which only exist
 #     there. Fails if moosh cannot bootstrap Moodle (the PR #149 regression on
 #     the 5.1+ public/ layout).
+#
+#   MODE=sync
+#     Moodle-context regression test for 010-sync-moodle-code.sh (#103). Must
+#     run INSIDE the `app` container. Simulates a stale moodlehtml volume
+#     (old stamp + leftover core file + custom plugin), re-runs the sync
+#     script, and asserts config/plugin preservation + core refresh.
 MODE="${1:-all}"
 
 # --------------------------------------------------------------------------
@@ -72,8 +78,113 @@ run_moosh_smoke_test() {
   echo "moosh Moodle-context smoke test passed."
 }
 
+# --------------------------------------------------------------------------
+# Moodle-context code-sync regression test (#103)
+# --------------------------------------------------------------------------
+run_sync_smoke_test() {
+  echo "== Moodle code sync smoke test (#103) =="
+
+  html="/var/www/html"
+  src="/usr/src/moodle"
+  script="/docker-entrypoint-init.d/010-sync-moodle-code.sh"
+  stamp="${html}/.alpine-moodle-release"
+
+  src_version_php=""
+  if [ -f "${src}/version.php" ]; then
+    src_version_php="${src}/version.php"
+  elif [ -f "${src}/public/version.php" ]; then
+    src_version_php="${src}/public/version.php"
+  fi
+  if [ -z "$src_version_php" ]; then
+    echo "ERROR: immutable Moodle source missing version.php under ${src} (or ${src}/public)"
+    exit 1
+  fi
+  if [ ! -f "$script" ]; then
+    echo "ERROR: sync script missing at $script"
+    exit 1
+  fi
+  if [ ! -f "${html}/config.php" ]; then
+    echo "ERROR: expected an installed site with config.php at ${html}/config.php"
+    exit 1
+  fi
+
+  image_ver="$(sed -n 's/^[[:space:]]*\$version[[:space:]]*=[[:space:]]*\([0-9][0-9.]*\).*/\1/p' \
+    "$src_version_php" | head -n 1)"
+  if [ -z "$image_ver" ]; then
+    echo "ERROR: could not parse image Moodle \$version from ${src_version_php}"
+    exit 1
+  fi
+  echo "Image Moodle \$version: ${image_ver} (from ${src_version_php})"
+
+  # Snapshot config.php so we can prove it survives the sync.
+  config_before="$(cksum < "${html}/config.php")"
+
+  # Simulate a stale volume: old stamp, a leftover core file, and a "custom" plugin.
+  printf '0.00\n' > "$stamp"
+  printf 'stale-core-from-old-image\n' > "${html}/STALE_CORE_FILE_FROM_OLD_IMAGE"
+  mkdir -p "${html}/local/syncsmoke"
+  printf '<?php // custom plugin marker for sync test\n' > "${html}/local/syncsmoke/version.php"
+  custom_before="$(cksum < "${html}/local/syncsmoke/version.php")"
+
+  echo "Re-running sync script with SYNC_MOODLE_CODE=auto and EXTRA_PLUGIN_PATHS=local/syncsmoke..."
+  SYNC_MOODLE_CODE=auto \
+  EXTRA_PLUGIN_PATHS="local/syncsmoke" \
+  sh "$script"
+
+  stamp_after="$(tr -d '[:space:]' < "$stamp")"
+  if [ "$stamp_after" != "$image_ver" ]; then
+    echo "ERROR: stamp not updated (got '${stamp_after}', want '${image_ver}')"
+    exit 1
+  fi
+  echo "Stamp updated to ${stamp_after}"
+
+  if [ -e "${html}/STALE_CORE_FILE_FROM_OLD_IMAGE" ]; then
+    echo "ERROR: stale core file was not removed by rsync --delete"
+    exit 1
+  fi
+  echo "Stale core file removed."
+
+  config_after="$(cksum < "${html}/config.php")"
+  if [ "$config_before" != "$config_after" ]; then
+    echo "ERROR: config.php changed during sync (before=${config_before} after=${config_after})"
+    exit 1
+  fi
+  echo "config.php preserved."
+
+  if [ ! -f "${html}/local/syncsmoke/version.php" ]; then
+    echo "ERROR: EXTRA_PLUGIN_PATHS custom plugin was not restored"
+    exit 1
+  fi
+  custom_after="$(cksum < "${html}/local/syncsmoke/version.php")"
+  if [ "$custom_before" != "$custom_after" ]; then
+    echo "ERROR: custom plugin content changed during sync"
+    exit 1
+  fi
+  echo "Custom plugin local/syncsmoke preserved."
+
+  # Second run with matching stamp must be a no-op (leave a local marker alone).
+  printf 'local-marker\n' > "${html}/SYNC_NOOP_MARKER"
+  SYNC_MOODLE_CODE=auto EXTRA_PLUGIN_PATHS="local/syncsmoke" sh "$script"
+  if [ ! -f "${html}/SYNC_NOOP_MARKER" ]; then
+    echo "ERROR: second auto sync with matching versions wiped a local marker (should no-op)"
+    exit 1
+  fi
+  echo "Matching-version auto sync is a no-op."
+
+  # Cleanup test artefacts so they don't pollute the running site.
+  rm -f "${html}/SYNC_NOOP_MARKER"
+  rm -rf "${html}/local/syncsmoke"
+
+  echo "Moodle code sync smoke test passed."
+}
+
 if [ "$MODE" = "moosh" ]; then
   run_moosh_smoke_test
+  exit 0
+fi
+
+if [ "$MODE" = "sync" ]; then
+  run_sync_smoke_test
   exit 0
 fi
 

--- a/tests/compose-test.sh
+++ b/tests/compose-test.sh
@@ -77,4 +77,13 @@ if ! dc exec -T -e MOODLE_VERSION="${MOODLE_VERSION}" app sh /tmp/run_tests.sh m
   exit 1
 fi
 
+# 3) Moodle code-sync regression test (#103): stale volume → rsync core, keep
+#    config.php + EXTRA_PLUGIN_PATHS. Runs inside app (needs real trees).
+echo ">> Running the Moodle code-sync smoke test inside app..."
+if ! dc exec -T app sh /tmp/run_tests.sh sync; then
+  echo "ERROR: code-sync smoke test failed for Moodle ${MOODLE_VERSION} (${FILE})."
+  dump_logs
+  exit 1
+fi
+
 echo ">> All checks passed for Moodle ${MOODLE_VERSION} (${FILE})."

--- a/tests/unit/test-sync-moodle-code.sh
+++ b/tests/unit/test-sync-moodle-code.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env sh
+#
+# tests/unit/test-sync-moodle-code.sh
+#
+# Fast, docker-free unit tests for 010-sync-moodle-code.sh.
+# Builds a miniature "image" tree and a "volume" tree, exercises auto/always/never
+# and EXTRA_PLUGIN_PATHS preservation.
+#
+# Run from the repository root:
+#   ./tests/unit/test-sync-moodle-code.sh
+#
+set -eu
+
+ROOT="$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)"
+SCRIPT="${ROOT}/rootfs/docker-entrypoint-init.d/010-sync-moodle-code.sh"
+FAILED=0
+
+if [ ! -x "$SCRIPT" ] && [ -f "$SCRIPT" ]; then
+  chmod +x "$SCRIPT"
+fi
+if [ ! -f "$SCRIPT" ]; then
+  echo "ERROR: sync script not found at $SCRIPT"
+  exit 1
+fi
+if ! command -v rsync >/dev/null 2>&1; then
+  echo "ERROR: rsync is required for these tests"
+  exit 1
+fi
+
+assert_eq() {
+  label="$1"
+  expected="$2"
+  actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  PASS: $label"
+  else
+    echo "  FAIL: $label (expected='$expected' actual='$actual')"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+assert_file() {
+  label="$1"
+  path="$2"
+  if [ -e "$path" ]; then
+    echo "  PASS: $label"
+  else
+    echo "  FAIL: $label (missing $path)"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+assert_no_file() {
+  label="$1"
+  path="$2"
+  if [ ! -e "$path" ]; then
+    echo "  PASS: $label"
+  else
+    echo "  FAIL: $label (still exists: $path)"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+# Tiny Moodle-like tree: only version.php + a couple of markers.
+seed_tree() {
+  dest="$1"
+  ver="$2"
+  marker_content="$3"
+  rm -rf "$dest"
+  mkdir -p "$dest/lib" "$dest/mod/forum"
+  printf '%s\n' "<?php" "\$version  = ${ver};" "\$release  = 'test';" "\$branch   = '000';" \
+    > "$dest/version.php"
+  printf '%s\n' "$marker_content" > "$dest/lib/moodlelib.php"
+  printf 'core-forum\n' > "$dest/mod/forum/version.php"
+}
+
+run_sync() {
+  # shellcheck disable=SC2030,SC2031
+  SYNC_MOODLE_CODE="${SYNC_MOODLE_CODE:-auto}" \
+  EXTRA_PLUGIN_PATHS="${EXTRA_PLUGIN_PATHS:-}" \
+  MOODLE_SRC_DIR="$SRC" \
+  MOODLE_HTML_DIR="$HTML" \
+  sh "$SCRIPT"
+}
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+SRC="${WORKDIR}/src"
+HTML="${WORKDIR}/html"
+
+echo "== test 1: auto seeds empty volume =="
+seed_tree "$SRC" "2025041402.00" "image-core-v2"
+rm -rf "$HTML"
+mkdir -p "$HTML"
+SYNC_MOODLE_CODE=auto EXTRA_PLUGIN_PATHS= run_sync
+assert_file "version.php copied" "${HTML}/version.php"
+assert_eq "stamp written" "2025041402.00" "$(tr -d '[:space:]' < "${HTML}/.alpine-moodle-release")"
+assert_eq "core content from image" "image-core-v2" "$(cat "${HTML}/lib/moodlelib.php")"
+
+echo "== test 2: auto is a no-op when versions match =="
+# Drop a local marker; sync must NOT wipe it if versions already match.
+printf 'local-only\n' > "${HTML}/local-only.txt"
+SYNC_MOODLE_CODE=auto EXTRA_PLUGIN_PATHS= run_sync
+assert_file "local file kept when in sync" "${HTML}/local-only.txt"
+
+echo "== test 3: auto upgrades and deletes leftover core files =="
+seed_tree "$SRC" "2025041402.00" "image-core-v2"
+seed_tree "$HTML" "2025041401.00" "old-core-v1"
+printf 'stale-core-file\n' > "${HTML}/STALE_CORE_FILE"
+printf '<?php // site config\n' > "${HTML}/config.php"
+mkdir -p "${HTML}/mod/attendance"
+printf 'custom-plugin\n' > "${HTML}/mod/attendance/version.php"
+# Also drop a local-only file that is NOT in EXTRA_PLUGIN_PATHS → should be deleted by --delete
+printf 'junk\n' > "${HTML}/will-be-deleted.txt"
+
+SYNC_MOODLE_CODE=auto \
+EXTRA_PLUGIN_PATHS="mod/attendance" \
+run_sync
+
+assert_eq "stamp upgraded" "2025041402.00" "$(tr -d '[:space:]' < "${HTML}/.alpine-moodle-release")"
+assert_eq "core replaced" "image-core-v2" "$(cat "${HTML}/lib/moodlelib.php")"
+assert_eq "config.php preserved" "<?php // site config" "$(cat "${HTML}/config.php")"
+assert_eq "custom plugin preserved" "custom-plugin" "$(cat "${HTML}/mod/attendance/version.php")"
+assert_file "core mod/forum from image" "${HTML}/mod/forum/version.php"
+assert_no_file "stale core file removed" "${HTML}/STALE_CORE_FILE"
+assert_no_file "non-extra local file removed" "${HTML}/will-be-deleted.txt"
+
+echo "== test 4: never never syncs =="
+seed_tree "$SRC" "2025041402.00" "image-core-v2"
+seed_tree "$HTML" "2025041401.00" "old-core-v1"
+printf 'stale\n' > "${HTML}/STALE_CORE_FILE"
+SYNC_MOODLE_CODE=never EXTRA_PLUGIN_PATHS= run_sync
+assert_eq "core unchanged under never" "old-core-v1" "$(cat "${HTML}/lib/moodlelib.php")"
+assert_file "stale kept under never" "${HTML}/STALE_CORE_FILE"
+
+echo "== test 5: always syncs even when versions match =="
+seed_tree "$SRC" "2025041402.00" "image-core-v2"
+seed_tree "$HTML" "2025041402.00" "tampered-core"
+printf '2025041402.00\n' > "${HTML}/.alpine-moodle-release"
+printf 'local-only\n' > "${HTML}/local-only.txt"
+SYNC_MOODLE_CODE=always EXTRA_PLUGIN_PATHS= run_sync
+assert_eq "always re-applies image core" "image-core-v2" "$(cat "${HTML}/lib/moodlelib.php")"
+assert_no_file "always deletes local-only files" "${HTML}/local-only.txt"
+
+echo "== test 6: rejects unsafe EXTRA_PLUGIN_PATHS =="
+seed_tree "$SRC" "2025041402.00" "image-core-v2"
+seed_tree "$HTML" "2025041401.00" "old-core-v1"
+set +e
+out="$(
+  SYNC_MOODLE_CODE=auto \
+  EXTRA_PLUGIN_PATHS="../etc/passwd" \
+  MOODLE_SRC_DIR="$SRC" \
+  MOODLE_HTML_DIR="$HTML" \
+  sh "$SCRIPT" 2>&1
+)"
+rc=$?
+set -e
+if [ "$rc" -ne 0 ] && echo "$out" | grep -qi 'invalid EXTRA_PLUGIN_PATHS'; then
+  echo "  PASS: unsafe path rejected"
+else
+  echo "  FAIL: unsafe path was not rejected (rc=$rc)"
+  echo "$out"
+  FAILED=$((FAILED + 1))
+fi
+
+echo "== test 7: Moodle 5.1+ public/ version.php layout =="
+# Image tree only has public/version.php (no root version.php).
+rm -rf "$SRC" "$HTML"
+mkdir -p "$SRC/public/lib" "$HTML/public/lib"
+printf '%s\n' "<?php" "\$version  = 2026071400.00;" > "$SRC/public/version.php"
+printf 'image-public-core\n' > "$SRC/public/lib/moodlelib.php"
+printf '%s\n' "<?php" "\$version  = 2025041401.00;" > "$HTML/public/version.php"
+printf 'old-public-core\n' > "$HTML/public/lib/moodlelib.php"
+printf '<?php // cfg\n' > "$HTML/config.php"
+SYNC_MOODLE_CODE=auto EXTRA_PLUGIN_PATHS= run_sync
+assert_eq "public layout stamp" "2026071400.00" "$(tr -d '[:space:]' < "${HTML}/.alpine-moodle-release")"
+assert_eq "public layout core replaced" "image-public-core" "$(cat "${HTML}/public/lib/moodlelib.php")"
+assert_file "config.php still present" "${HTML}/config.php"
+
+echo
+if [ "$FAILED" -eq 0 ]; then
+  echo "All unit tests passed."
+  exit 0
+fi
+echo "FAILED: ${FAILED} assertion(s)."
+exit 1


### PR DESCRIPTION
## Summary

Closes #103 (also fixes the root cause of #102 for operators who use a `moodlehtml` volume).

When `/var/www/html` is a named volume, Docker only seeds it from the image on first use. Later image upgrades left the old PHP tree on the volume, so `AUTO_UPDATE_MOODLE` only ran `admin/cli/upgrade.php` against stale code.

### What changed

1. **Dockerfile**
   - Install Moodle into immutable `/usr/src/moodle`
   - Seed `/var/www/html` from that tree
   - Write `.alpine-moodle-release` (Moodle `$version` id)
   - Add `rsync`
   - Defaults: `SYNC_MOODLE_CODE=auto`, `EXTRA_PLUGIN_PATHS=`

2. **`010-sync-moodle-code.sh`** (runs before plugin install / configure)
   - `auto` — sync when the volume is empty or `$version` differs from the image
   - `always` / `never` overrides
   - Preserve `config.php` and `EXTRA_PLUGIN_PATHS`
   - `rsync -a --delete --checksum` so leftover core files are removed
   - Supports pre-5.1 (`version.php`) and 5.1+ (`public/version.php`)

3. **Docs** — persistence, upgrading, env vars, FAQ, README

4. **Tests**
   - `./tests/unit/test-sync-moodle-code.sh` — 7 docker-free cases (auto/always/never, preserve paths, public/ layout, path traversal reject)
   - `run_tests.sh sync` — in-container regression on a live install (wired into `tests/compose-test.sh`)

### Operator UX

```yaml
services:
  moodle:
    image: erseco/alpine-moodle:v5.0.2   # only change the tag
    volumes:
      - moodledata:/var/www/moodledata
      - moodlehtml:/var/www/html
    environment:
      SYNC_MOODLE_CODE: auto              # default
      EXTRA_PLUGIN_PATHS: "mod/attendance theme/space"
```

```bash
docker compose pull && docker compose up -d
# log: Moodle code sync: 2025041401.00 → 2025041402.00
```

Legacy “volume always wins”: `SYNC_MOODLE_CODE=never`.

## Test plan

- [x] `./tests/unit/test-sync-moodle-code.sh` — all 7 assertions pass
- [x] `./tests/compose-test.sh docker-compose.test.sqlite.yml` — HTTP + moosh + **sync** all pass on Moodle `main` (5.1+ `public/` layout)
- [ ] CI unit test step on PR
- [ ] Matrix / push smoke picks up the new `sync` mode via `compose-test.sh`