### PR TITLE
Prevent fork pull requests from running GitHub Actions

### DIFF
--- a/.github/workflows/blueprint-tests.yml
+++ b/.github/workflows/blueprint-tests.yml
@@ -24,6 +24,7 @@ on:
 
 jobs:
   blueprint-tests:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   buildx:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       # Step 1: Checkout the code

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,8 +17,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -26,6 +24,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -54,6 +53,10 @@ jobs:
     if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/moodle-matrix-tests.yml
+++ b/.github/workflows/moodle-matrix-tests.yml
@@ -26,6 +26,7 @@ concurrency:
 jobs:
   # PostgreSQL (the default backend) covers every Moodle version.
   postgres:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     name: "Moodle ${{ matrix.moodle }} · PostgreSQL"
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -43,6 +44,7 @@ jobs:
 
   # MariaDB on a representative subset: one legacy + one public/ layout.
   mariadb:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     name: "Moodle ${{ matrix.moodle }} · MariaDB"
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -63,6 +65,7 @@ jobs:
   # ateeducacion/moodle SQLite patch: PR #1 (5.2/main), PR #2 (5.1), PR #3 (5.0)
   # and PR #4 (4.5). See specs/ci-moodle-sqlite-4.5-5.x.md.
   sqlite:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     name: "Moodle ${{ matrix.moodle }} · SQLite"
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
## Summary

- skip pull-request jobs when the source branch belongs to a fork
- keep same-repository pull requests, pushes, scheduled runs, and manual dispatches working
- scope GitHub Pages and OIDC write permissions to the deployment job

## Security rationale

Pull request workflows execute code supplied by the pull request. Blocking jobs from forks prevents untrusted code from consuming runner and network resources and reduces exposure if workflow permissions change in the future.