### PR TITLE
Restore CI for approved fork pull requests

### DIFF
--- a/.github/workflows/blueprint-tests.yml
+++ b/.github/workflows/blueprint-tests.yml
@@ -24,7 +24,6 @@ on:
 
 jobs:
   blueprint-tests:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,6 @@ on:
 
 jobs:
   buildx:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       # Step 1: Checkout the code

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,8 @@ on:
 
 permissions:
   contents: read
+  pages: write
+  id-token: write
 
 concurrency:
   group: pages
@@ -24,7 +26,6 @@ concurrency:
 
 jobs:
   build:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -53,10 +54,6 @@ jobs:
     if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/moodle-matrix-tests.yml
+++ b/.github/workflows/moodle-matrix-tests.yml
@@ -26,7 +26,6 @@ concurrency:
 jobs:
   # PostgreSQL (the default backend) covers every Moodle version.
   postgres:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     name: "Moodle ${{ matrix.moodle }} · PostgreSQL"
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -44,7 +43,6 @@ jobs:
 
   # MariaDB on a representative subset: one legacy + one public/ layout.
   mariadb:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     name: "Moodle ${{ matrix.moodle }} · MariaDB"
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -65,7 +63,6 @@ jobs:
   # ateeducacion/moodle SQLite patch: PR #1 (5.2/main), PR #2 (5.1), PR #3 (5.0)
   # and PR #4 (4.5). See specs/ci-moodle-sqlite-4.5-5.x.md.
   sqlite:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     name: "Moodle ${{ matrix.moodle }} · SQLite"
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
## Summary

- revert the fork-specific workflow restrictions introduced in #159
- restore the previous GitHub Pages permission layout
- allow normal pull request workflows to run after GitHub's external-contributor approval gate

## Rationale

The repository should use **Require approval for all external contributors**. This preserves manual approval while allowing maintainers to run CI for legitimate external contributions.