### PR TITLE
Guarantee published images match their Moodle version tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,26 +81,49 @@ jobs:
           sarif_file: hadolint-results.sarif
           category: hadolint-dockerfile
 
-      # Step 7: Determine Moodle version
+      # Step 7: Determine Moodle version and resolve the exact upstream commit.
+      # Passing the commit as MOODLE_COMMIT keys the Docker download layer to
+      # upstream's HEAD, so a stale BuildKit cache can never freeze the Moodle
+      # code shipped in :main/:beta again (#161). Resolving it here also fails
+      # the build early when a tag does not exist in moodle/moodle.
       - name: Determine Moodle version
         id: moodle_version
         run: |
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
-            echo "version=${VERSION}" >> $GITHUB_OUTPUT
+            REF="refs/tags/${VERSION}"
           else
-            echo "version=main" >> $GITHUB_OUTPUT
+            VERSION=main
+            REF="refs/heads/main"
           fi
+          # tail -1: for annotated tags the peeled ^{} line (the commit) sorts last.
+          COMMIT=$(git ls-remote https://github.com/moodle/moodle.git "$REF" "${REF}^{}" | tail -n 1 | cut -f1)
+          if [[ -z "$COMMIT" ]]; then
+            echo "ERROR: ${REF} not found in moodle/moodle — refusing to build" >&2
+            exit 1
+          fi
+          echo "Resolved ${VERSION} -> ${COMMIT}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "commit=${COMMIT}" >> $GITHUB_OUTPUT
 
-      # Fast, docker-free coverage of 010-sync-moodle-code.sh (#103).
-      - name: Unit test (Moodle code sync)
-        run: ./tests/unit/test-sync-moodle-code.sh
+      # Fast, docker-free coverage of the shell helpers (#103, #161).
+      - name: Unit tests (shell scripts)
+        run: |
+          for t in tests/unit/*.sh; do
+            echo "== ${t}"
+            "$t"
+          done
 
-      # Step 8: Test build (for PRs)
+      # Step 8: Test build (for PRs). Passes the same version/commit args as
+      # the release build so the MOODLE_COMMIT download path is exercised
+      # before merging.
       - name: Debug Build on PR
         if: github.event_name == 'pull_request'
         run: |
-          docker buildx build --load .
+          docker buildx build --load \
+            --build-arg MOODLE_VERSION=${{ steps.moodle_version.outputs.version }} \
+            --build-arg MOODLE_COMMIT=${{ steps.moodle_version.outputs.commit }} \
+            .
 
       # Steps 9x: Functional tests (HTTP web check + Moodle-context moosh smoke
       # + code-sync regression) via the shared orchestrator tests/compose-test.sh.
@@ -119,7 +142,20 @@ jobs:
         if: github.event_name != 'pull_request'
         run: ./tests/compose-test.sh docker-compose.test.sqlite.yml
 
-      # Step 10: Build and Push to both registries in a single step
+      # Step 10: Release gate (#161). Build the amd64 image locally and assert
+      # the Moodle code inside actually matches the tag being built BEFORE
+      # anything is pushed. The multi-arch push below reuses these layers from
+      # the builder's local cache, so this costs almost nothing.
+      - name: Verify image Moodle version
+        if: github.event_name != 'pull_request'
+        run: |
+          docker buildx build --load \
+            --build-arg MOODLE_VERSION=${{ steps.moodle_version.outputs.version }} \
+            --build-arg MOODLE_COMMIT=${{ steps.moodle_version.outputs.commit }} \
+            -t alpine-moodle:verify .
+          ./tests/verify-moodle-version.sh alpine-moodle:verify "${{ steps.moodle_version.outputs.version }}"
+
+      # Step 11: Build and Push to both registries in a single step
       - name: Build and push
         if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v7
@@ -130,20 +166,24 @@ jobs:
           platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/386,linux/ppc64le,linux/s390x
           build-args: |
             MOODLE_VERSION=${{ steps.moodle_version.outputs.version }}
+            MOODLE_COMMIT=${{ steps.moodle_version.outputs.commit }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # Step 11: Run Trivy vulnerability scanner
+      # Step 12: Run Trivy vulnerability scanner. The docker tag pushed above
+      # always matches the version output (vX.Y.Z for tag builds, main for
+      # main-branch builds); the previous tags[0] expression silently
+      # resolved to 'main' on every build.
       - name: Run Trivy vulnerability scanner
         if: github.event_name != 'pull_request'
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.tags && steps.meta.outputs.tags[0] || 'main' }}
+          image-ref: ghcr.io/${{ github.repository }}:${{ steps.moodle_version.outputs.version }}
           format: 'table'
           exit-code: '0'
           severity: 'CRITICAL,HIGH'
 
-      # Step 12: Update Docker Hub Description
+      # Step 13: Update Docker Hub Description
       - name: Docker Hub Description
         if: startsWith(github.ref, 'refs/tags/')
         uses: peter-evans/dockerhub-description@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,17 +129,25 @@ jobs:
       # + code-sync regression) via the shared orchestrator tests/compose-test.sh.
       # On pull requests the dedicated moodle-matrix workflow already runs these
       # across every supported Moodle version, so here they run only on
-      # push/dispatch as a release smoke test (Moodle main, the default MOODLE_VERSION).
+      # push/dispatch as a release smoke test. They test the Moodle version
+      # actually being built (#161): a tag build must not be blocked — or,
+      # worse, greenlit — by whatever state upstream main is in that day.
       - name: Test (PostgreSQL)
         if: github.event_name != 'pull_request'
+        env:
+          MOODLE_VERSION: ${{ steps.moodle_version.outputs.version }}
         run: ./tests/compose-test.sh docker-compose.test.yml
 
       - name: Test (MariaDB)
         if: github.event_name != 'pull_request'
+        env:
+          MOODLE_VERSION: ${{ steps.moodle_version.outputs.version }}
         run: ./tests/compose-test.sh docker-compose.test.mariadb.yml
 
       - name: Test (SQLite)
         if: github.event_name != 'pull_request'
+        env:
+          MOODLE_VERSION: ${{ steps.moodle_version.outputs.version }}
         run: ./tests/compose-test.sh docker-compose.test.sqlite.yml
 
       # Step 10: Release gate (#161). Build the amd64 image locally and assert

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,12 @@ USER nobody
 
 # Moodle version configuration
 ARG MOODLE_VERSION=main
+# Exact moodle/moodle commit for the download below. CI (build.yml) resolves
+# it from MOODLE_VERSION with git ls-remote, so the download layer's cache key
+# changes whenever upstream moves — without it, BuildKit reused a months-old
+# cached "main" snapshot in every :main/:beta image (#161). Optional for local
+# builds: when empty, the ref name is downloaded directly.
+ARG MOODLE_COMMIT=
 
 # Set default environment variables
 ENV LANG=en_US.UTF-8 \
@@ -80,16 +86,23 @@ ENV LANG=en_US.UTF-8 \
 # Example:
 # MOODLE_VERSION=v4.5.3
 #
+# MOODLE_COMMIT (optional) pins the exact commit to download; when set it
+# takes precedence over MOODLE_VERSION for the URL.
+#
 # Download and extract Moodle into the immutable source tree, then seed the
 # runtime document root. Runtime upgrades of a persistent moodlehtml volume are
 # handled by rootfs/docker-entrypoint-init.d/010-sync-moodle-code.sh.
-RUN if [ "$MOODLE_VERSION" = "main" ]; then \
-      MOODLE_URL="https://github.com/moodle/moodle/archive/main.tar.gz"; \
+RUN if [ -n "$MOODLE_COMMIT" ]; then \
+      MOODLE_URL="https://github.com/moodle/moodle/archive/${MOODLE_COMMIT}.tar.gz"; \
+    elif [ "$MOODLE_VERSION" = "main" ]; then \
+      MOODLE_URL="https://github.com/moodle/moodle/archive/refs/heads/main.tar.gz"; \
     else \
-      MOODLE_URL="https://github.com/moodle/moodle/tarball/refs/tags/${MOODLE_VERSION}"; \
+      MOODLE_URL="https://github.com/moodle/moodle/archive/refs/tags/${MOODLE_VERSION}.tar.gz"; \
     fi && \
-    echo "Downloading Moodle from: $MOODLE_URL" && \
-    curl -L "$MOODLE_URL" | tar xz --strip-components=1 -C /usr/src/moodle
+    echo "Downloading Moodle ${MOODLE_VERSION}${MOODLE_COMMIT:+ (commit ${MOODLE_COMMIT})} from: $MOODLE_URL" && \
+    curl -fsSL "$MOODLE_URL" -o /tmp/moodle.tar.gz && \
+    tar xzf /tmp/moodle.tar.gz --strip-components=1 -C /usr/src/moodle && \
+    rm -f /tmp/moodle.tar.gz
 
 # Apply experimental SQLite support (MDL-88218). The heavy lifting — selecting
 # the right ateeducacion/moodle patch per branch (PR #1 main, #5 5.2, #2 5.1,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -171,6 +171,22 @@ docker compose up -d
 
 See [Upgrading](upgrading.md) for the full procedure.
 
+## Site shows an older Moodle version than the image tag
+
+**Symptom**: You pull e.g. `erseco/alpine-moodle:v5.2.1` but the footer / `admin/environment.php` reports an older release (even a `X.Ydev` build), and plugins requiring the newer `$version` refuse to install. Related: [#161](https://github.com/erseco/alpine-moodle/issues/161).
+
+**Cause**: Docker seeds a named `moodlehtml` volume from the image only on **first** use. Afterwards the volume's old PHP tree shadows whatever newer image you pull, and `AUTO_UPDATE_MOODLE` alone never replaces code. Images built before the version-aware code sync landed (July 2026) cannot self-heal this.
+
+**Fix**: Pull the current image for your tag (all release tags have been rebuilt with `SYNC_MOODLE_CODE` support) and recreate the container:
+
+```bash
+docker compose pull
+docker compose up -d --force-recreate
+docker compose logs moodle | grep 'Moodle code sync'
+```
+
+The sync keeps `config.php` and any `EXTRA_PLUGIN_PATHS` entries, refreshes core to the image's release, and then the DB upgrade runs as usual.
+
 ## LDAP says the PHP module is missing
 
 **Cause**: Old image tag. `php-ldap` is bundled in current releases. Related: [#122](https://github.com/erseco/alpine-moodle/issues/122).

--- a/scripts/apply-sqlite-support.sh
+++ b/scripts/apply-sqlite-support.sh
@@ -68,11 +68,29 @@ fi
 # release's environment.xml also carries newer version stubs, so the highest
 # block is NOT the installed version (e.g. 4.5.12 declares blocks up to 5.2).
 #
-# For "main" the patch already declares sqlite in the newest (dev) block, so
-# there is nothing to normalise.
+# For "main" the block is resolved from the tree's $branch (e.g. '503' →
+# "5.3"): the patch only declares sqlite in the block that was newest when
+# its diff was written, so after a weekly dev-branch bump (5.2 → 5.3dev on
+# 2026-07-28) the tree's newest block predates the patch and the CLI
+# installer fails with "Error reading environment data".
 case "$MOODLE_VERSION" in
   v*) target="$(echo "$MOODLE_VERSION" | sed -E 's/^v([0-9]+\.[0-9]+).*/\1/')" ;;
-  *)  target="" ;;
+  *)
+    target=""
+    for vphp in "$DIR/version.php" "$DIR/public/version.php"; do
+      [ -f "$vphp" ] || continue
+      branch="$(awk -F"'" '/^\$branch/ {print $2; exit}' "$vphp")"
+      case "$branch" in
+        [0-9][0-9][0-9])
+          major="${branch%??}"
+          minor="${branch#"$major"}"
+          minor="${minor#0}"
+          target="${major}.${minor}"
+          ;;
+      esac
+      break
+    done
+    ;;
 esac
 
 if [ -n "$target" ]; then

--- a/tests/unit/test-verify-moodle-version.sh
+++ b/tests/unit/test-verify-moodle-version.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env sh
+#
+# tests/unit/test-verify-moodle-version.sh
+#
+# Fast, docker-free unit tests for tests/verify-moodle-version.sh (#161).
+# Stubs the docker CLI with a script that emits a canned version.php, so the
+# parsing and match/mismatch logic can be exercised without images.
+#
+# Run from the repository root:
+#   ./tests/unit/test-verify-moodle-version.sh
+#
+set -eu
+
+ROOT="$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)"
+SCRIPT="${ROOT}/tests/verify-moodle-version.sh"
+FAILED=0
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "ERROR: verify script not found at $SCRIPT"
+  exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Stub docker: ignores every argument and prints the canned version.php that
+# the current test case wrote to $STUB_VERSION_PHP.
+mkdir -p "$WORK/bin"
+cat > "$WORK/bin/docker" <<'EOF'
+#!/usr/bin/env sh
+cat "$STUB_VERSION_PHP"
+EOF
+chmod +x "$WORK/bin/docker"
+PATH="$WORK/bin:$PATH"
+export STUB_VERSION_PHP="$WORK/version.php"
+
+# run_case LABEL EXPECTED_EXIT TAG
+# The canned version.php must already be in $STUB_VERSION_PHP.
+run_case() {
+  label="$1"
+  expected_exit="$2"
+  tag="$3"
+  set +e
+  sh "$SCRIPT" fake-image:latest "$tag" > "$WORK/out.log" 2>&1
+  actual_exit=$?
+  set -e
+  if [ "$actual_exit" = "$expected_exit" ]; then
+    echo "  PASS: $label"
+  else
+    echo "  FAIL: $label (expected exit=$expected_exit actual=$actual_exit)"
+    sed 's/^/        /' "$WORK/out.log"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+write_release() {
+  cat > "$STUB_VERSION_PHP" <<EOF
+\$version  = ${2:-2026042001.00};              // 20260420      = branching date YYYYMMDD - do not modify!
+\$release  = '$1';    // Human-friendly version name
+\$branch   = '502';                      // This version's branch.
+EOF
+}
+
+echo "== stable tag matches release"
+write_release "5.2.1 (Build: 20260608)"
+run_case "v5.2.1 vs 5.2.1" 0 v5.2.1
+
+echo "== stable tag vs stale dev snapshot (the #161 scenario)"
+write_release "5.2dev (Build: 20251219)"
+run_case "v5.2.1 vs 5.2dev" 1 v5.2.1
+
+echo "== stable tag vs weekly + build must not pass"
+write_release "5.2.1+ (Build: 20260612)"
+run_case "v5.2.1 vs 5.2.1+" 1 v5.2.1
+
+echo "== pre-5.1 root layout release string"
+write_release "4.5.12 (Build: 20260608)" 2024100712.00
+run_case "v4.5.12 vs 4.5.12" 0 v4.5.12
+
+echo "== main only requires a parseable release"
+write_release "5.3dev (Build: 20260724)"
+run_case "main vs 5.3dev" 0 main
+
+echo "== pre-release tags skip the strict match"
+write_release "5.2rc2 (Build: 20260410)"
+run_case "v5.2.0-rc2 vs 5.2rc2" 0 v5.2.0-rc2
+write_release "5.2beta (Build: 20260320)"
+run_case "v5.2.0-beta vs 5.2beta" 0 v5.2.0-beta
+
+echo "== missing/unparseable version.php fails"
+: > "$STUB_VERSION_PHP"
+run_case "empty version.php" 1 v5.2.1
+run_case "empty version.php (main)" 1 main
+
+echo "== unexpected tag format fails"
+write_release "5.2.1 (Build: 20260608)"
+run_case "garbage expected version" 1 not-a-version
+
+if [ "$FAILED" -gt 0 ]; then
+  echo "FAILED: $FAILED case(s)"
+  exit 1
+fi
+echo "All verify-moodle-version tests passed."

--- a/tests/verify-moodle-version.sh
+++ b/tests/verify-moodle-version.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env sh
+#
+# tests/verify-moodle-version.sh IMAGE EXPECTED
+#
+# Release gate for #161: refuse to publish an image whose baked-in Moodle
+# code does not match the git tag being built.
+#
+#   IMAGE     local docker image to inspect
+#   EXPECTED  vX.Y.Z git tag, or "main" for main-branch snapshots
+#
+# Stable tags (vX.Y.Z) must match version.php's $release exactly
+# ("X.Y.Z (Build: ...)" — a weekly "X.Y.Z+" does NOT pass). Pre-release tags
+# (v5.2.0-rc1, v5.2.0-beta) and main only require a parseable release, since
+# upstream's pre-release $release strings ("5.2rc1") don't map 1:1 to tag
+# names.
+set -eu
+
+IMAGE="${1:?usage: verify-moodle-version.sh IMAGE vX.Y.Z|main}"
+EXPECTED="${2:?usage: verify-moodle-version.sh IMAGE vX.Y.Z|main}"
+
+# Moodle <5.1 keeps version.php at the tree root; 5.1+ moved it under public/.
+version_php=$(docker run --rm --entrypoint sh "$IMAGE" -c \
+  'cat /var/www/html/public/version.php /var/www/html/version.php 2>/dev/null || true')
+
+release_line=$(printf '%s\n' "$version_php" \
+  | grep -E '^[[:space:]]*\$release[[:space:]]*=' | head -n 1 || true)
+release=${release_line#*\'}
+release=${release%%\'*}
+
+if [ -z "$release" ] || [ "$release" = "$release_line" ]; then
+  echo "ERROR: could not read \$release from version.php in $IMAGE" >&2
+  exit 1
+fi
+echo "Image $IMAGE contains Moodle release: $release"
+
+case "$EXPECTED" in
+  main|*-rc*|*-beta*)
+    echo "OK: no strict release match required for '$EXPECTED' builds."
+    ;;
+  v*.*.*)
+    want="${EXPECTED#v}"
+    case "$release" in
+      "$want"|"$want "*)
+        echo "OK: release matches tag $EXPECTED."
+        ;;
+      *)
+        echo "ERROR: image Moodle release '$release' does not match tag $EXPECTED" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    echo "ERROR: unrecognised expected version '$EXPECTED' (want vX.Y.Z or main)" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Closes #161.

## Problem

@Mordecaine reported that `v5.2.1` served Moodle `5.2dev (Build: 20251219)`. Investigation found two distinct defects:

1. **Frozen `:main`/`:beta` images.** The Moodle download `RUN` had a constant cache key for `MOODLE_VERSION=main`, so BuildKit's GHA cache reused the layer downloaded on ~2025-12-19 for every main-branch build for ~7 months (the 2026-07-07 main build log shows the download step as `CACHED`). Anyone who used `:main`/`:beta` in that window seeded their `moodlehtml` volume with that frozen 5.2dev snapshot.
2. **No guard on published content.** Nothing verified that the Moodle code inside an image actually matched the git tag being built before pushing to registries.

(The reporter's remaining symptom — the volume shadowing newer images — is fixed by the code sync from #103/#156; the release tags will be re-created after this merges so the published images include it.)

## Changes

- **Pin the Moodle download to the exact upstream commit.** `build.yml` resolves the tag/branch to a commit SHA via `git ls-remote` and passes it as the new `MOODLE_COMMIT` build-arg; the Dockerfile downloads `archive/<sha>.tar.gz`. The download layer's cache key now follows upstream, a missing upstream tag fails the build early, and `curl -fsSL` makes HTTP errors fatal.
- **Release gate before push** (`tests/verify-moodle-version.sh` + unit tests): builds the amd64 image and asserts `version.php`'s `$release` matches the tag (strict for stable `vX.Y.Z`; presence-only for `main`/pre-releases). Nothing is pushed if the content is wrong.
- PR debug builds exercise the pinned-commit path; unit-test step now runs everything in `tests/unit/`.
- Fix Trivy `image-ref` (the old `tags[0]` expression always resolved to `:main`).
- Troubleshooting docs: new section for the stale-volume symptom.

## Verification

- `tests/unit/test-verify-moodle-version.sh`: 10/10 cases pass (match, stale-dev mismatch, weekly `+` rejection, pre-5.1 root layout, main, rc/beta, empty, garbage).
- Verify script tested against the real published image (`erseco/alpine-moodle:v5.2.1` ⇒ OK) and negative case (⇒ exit 1).
- Full local docker build via the `MOODLE_COMMIT` path + gate: `OK: release matches tag v5.2.1`.
- All four download URL branches validated against GitHub (200/200/200, nonexistent tag ⇒ hard 404 failure).